### PR TITLE
Add battle engine scaffolding

### DIFF
--- a/src/engine/Abilities.ts
+++ b/src/engine/Abilities.ts
@@ -1,0 +1,17 @@
+/**
+ * Pokemon abilities that trigger under certain conditions.
+ */
+
+export interface Ability {
+  readonly name: string
+  onStart?: () => void
+  onBeforeMove?: () => void
+  onAfterMove?: () => void
+}
+
+export const ABILITIES: Record<string, Ability> = {
+  Overgrow: { name: 'Overgrow' },
+  Blaze: { name: 'Blaze' },
+  Torrent: { name: 'Torrent' },
+  // ...others truncated
+}

--- a/src/engine/BattleCalculator.ts
+++ b/src/engine/BattleCalculator.ts
@@ -1,0 +1,14 @@
+/**
+ * Contains combat formulas such as damage and accuracy.
+ */
+
+import type { Pokemon } from './Pokemon'
+import type { MoveData } from './Interfaces'
+
+export class BattleCalculator {
+  /** Calculate damage from an attacker using a move on a defender. */
+  static calculateDamage(attacker: Pokemon, defender: Pokemon, move: MoveData): number {
+    // Placeholder damage formula
+    return move.power
+  }
+}

--- a/src/engine/BattleEngine.ts
+++ b/src/engine/BattleEngine.ts
@@ -1,0 +1,27 @@
+/**
+ * Orchestrates the flow of a Pokemon battle.
+ */
+
+import { BattleState } from './BattleState'
+import { BattleCalculator } from './BattleCalculator'
+
+export class BattleEngine {
+  state: BattleState
+  calculator: BattleCalculator
+
+  constructor(state = new BattleState(), calculator = new BattleCalculator()) {
+    this.state = state
+    this.calculator = calculator
+  }
+
+  /** Execute a turn in the battle. */
+  takeTurn(): void {
+    this.state.turn++
+    // TODO: integrate move selection and damage calculation
+  }
+
+  /** Determine the winner and end the battle. */
+  endBattle(): void {
+    // TODO
+  }
+}

--- a/src/engine/BattleState.ts
+++ b/src/engine/BattleState.ts
@@ -1,0 +1,13 @@
+/**
+ * Runtime representation of the current battle state.
+ */
+
+import type { Pokemon } from './Pokemon'
+
+export class BattleState {
+  turn = 0
+  party1: Pokemon[] = []
+  party2: Pokemon[] = []
+
+  constructor() {}
+}

--- a/src/engine/Constants.ts
+++ b/src/engine/Constants.ts
@@ -1,0 +1,6 @@
+/**
+ * Basic constants used throughout the battle engine.
+ */
+
+export const DEFAULT_LEVEL = 50
+export const MAX_STAT_STAGE = 6

--- a/src/engine/Immunities.ts
+++ b/src/engine/Immunities.ts
@@ -1,0 +1,8 @@
+/**
+ * Special-case immunities that override type chart logic.
+ */
+
+export const IMMUNITIES: Record<string, string[]> = {
+  Ground: ['levitate'],
+  Psychic: ['dark'],
+}

--- a/src/engine/Interfaces.ts
+++ b/src/engine/Interfaces.ts
@@ -1,0 +1,21 @@
+/**
+ * Shared interfaces for the battle engine.
+ */
+
+export interface Stats {
+  hp: number
+  attack: number
+  defense: number
+  specialAttack: number
+  specialDefense: number
+  speed: number
+}
+
+export interface MoveData {
+  name: string
+  type: string
+  power: number
+  accuracy: number
+  pp: number
+  priority?: number
+}

--- a/src/engine/MoveEffects.ts
+++ b/src/engine/MoveEffects.ts
@@ -1,0 +1,14 @@
+/**
+ * Implementation of move side effects.
+ */
+
+export type MoveEffect = (user: any, target: any) => void
+
+export const MOVE_EFFECTS: Record<string, MoveEffect> = {
+  Drain: (user, target) => {
+    /* TODO */
+  },
+  BoostAttack: (user, target) => {
+    /* TODO */
+  },
+}

--- a/src/engine/Moves.ts
+++ b/src/engine/Moves.ts
@@ -1,0 +1,11 @@
+/**
+ * Static move metadata.
+ */
+
+import type { MoveData } from './Interfaces'
+
+export const MOVES: Record<string, MoveData> = {
+  Tackle: { name: 'Tackle', type: 'Normal', power: 40, accuracy: 100, pp: 35 },
+  Ember: { name: 'Ember', type: 'Fire', power: 40, accuracy: 100, pp: 25 },
+  // ...others trimmed
+}

--- a/src/engine/Natures.ts
+++ b/src/engine/Natures.ts
@@ -1,0 +1,15 @@
+import type { Stats } from "./Interfaces"
+/**
+ * Pokemon natures that modify stats.
+ */
+
+export interface NatureEffect {
+  readonly increase: keyof Stats
+  readonly decrease: keyof Stats
+}
+
+export const NATURES: Record<string, NatureEffect> = {
+  Hardy: { increase: 'attack', decrease: 'attack' },
+  Lonely: { increase: 'attack', decrease: 'defense' },
+  // ...others trimmed for brevity
+}

--- a/src/engine/Pokemon.ts
+++ b/src/engine/Pokemon.ts
@@ -1,0 +1,18 @@
+/**
+ * Core Pokemon class representing a combatant.
+ */
+
+import type { Stats } from './Interfaces'
+import { DEFAULT_LEVEL } from './Constants'
+
+export class Pokemon {
+  readonly name: string
+  level: number
+  stats: Stats
+
+  constructor(name: string, stats: Stats, level = DEFAULT_LEVEL) {
+    this.name = name
+    this.level = level
+    this.stats = stats
+  }
+}

--- a/src/engine/PokemonFactory.ts
+++ b/src/engine/PokemonFactory.ts
@@ -1,0 +1,20 @@
+/**
+ * Factory utilities for creating Pokemon instances.
+ */
+
+import { Pokemon } from './Pokemon'
+import type { Stats } from './Interfaces'
+import { DEFAULT_LEVEL } from './Constants'
+
+export class PokemonFactory {
+  /** Create a basic Pokemon with given stats. */
+  static create(name: string, stats: Stats, level = DEFAULT_LEVEL): Pokemon {
+    return new Pokemon(name, stats, level)
+  }
+
+  /** TODO: generate random legal Pokemon across generations. */
+  static random(): Pokemon {
+    return new Pokemon('MissingNo', { hp: 1, attack: 1, defense: 1, specialAttack: 1, specialDefense: 1, speed: 1 })
+  }
+}
+

--- a/src/engine/Statuses.ts
+++ b/src/engine/Statuses.ts
@@ -1,0 +1,24 @@
+/**
+ * Status conditions and their behaviors.
+ */
+
+export enum StatusName {
+  Burn = 'burn',
+  Poison = 'poison',
+  Paralysis = 'paralysis',
+  Sleep = 'sleep',
+  Freeze = 'freeze',
+}
+
+export interface StatusEffect {
+  onBeforeMove?: () => boolean
+  onAfterTurn?: () => void
+}
+
+export const STATUS_EFFECTS: Record<StatusName, StatusEffect> = {
+  [StatusName.Burn]: {},
+  [StatusName.Poison]: {},
+  [StatusName.Paralysis]: {},
+  [StatusName.Sleep]: {},
+  [StatusName.Freeze]: {},
+}

--- a/src/engine/Switching.ts
+++ b/src/engine/Switching.ts
@@ -1,0 +1,15 @@
+/**
+ * Logic for switching Pokemon in and out of battle.
+ */
+
+export class Switching {
+  /** Validate if the requested switch is legal. */
+  static canSwitch(): boolean {
+    return true
+  }
+
+  /** Execute the switch. */
+  static performSwitch(): void {
+    // TODO
+  }
+}

--- a/src/engine/Types.ts
+++ b/src/engine/Types.ts
@@ -1,0 +1,30 @@
+/**
+ * Type effectiveness matrix.
+ */
+
+export type TypeName =
+  | 'Normal'
+  | 'Fire'
+  | 'Water'
+  | 'Grass'
+  | 'Electric'
+  | 'Ice'
+  | 'Fighting'
+  | 'Poison'
+  | 'Ground'
+  | 'Flying'
+  | 'Psychic'
+  | 'Bug'
+  | 'Rock'
+  | 'Ghost'
+  | 'Dragon'
+  | 'Dark'
+  | 'Steel'
+  | 'Fairy'
+
+export const TYPE_CHART: Record<TypeName, Partial<Record<TypeName, number>>> = {
+  Fire: { Grass: 2, Water: 0.5, Rock: 0.5, Steel: 2 },
+  Water: { Fire: 2, Grass: 0.5, Rock: 2 },
+  Grass: { Water: 2, Fire: 0.5, Ground: 2 },
+  // ...others trimmed
+}

--- a/src/engine/Utils.ts
+++ b/src/engine/Utils.ts
@@ -1,0 +1,17 @@
+/**
+ * Miscellaneous helper functions for the battle engine.
+ */
+
+/** Generate a random integer between min and max inclusive. */
+export function randInt(min: number, max: number): number {
+  return Math.floor(Math.random() * (max - min + 1)) + min
+}
+
+/** Shuffle an array in place. */
+export function shuffle<T>(arr: T[]): T[] {
+  for (let i = arr.length - 1; i > 0; i--) {
+    const j = randInt(0, i)
+    ;[arr[i], arr[j]] = [arr[j], arr[i]]
+  }
+  return arr
+}


### PR DESCRIPTION
## Summary
- add `engine` directory with empty TypeScript modules
- stub out classes for battle flow, pokemon data, moves and helpers

## Testing
- `npm run build` *(fails: vite not found)*