### PR TITLE
Add RNG helper and basic demo

### DIFF
--- a/src/engine/BattleCalculator.ts
+++ b/src/engine/BattleCalculator.ts
@@ -12,47 +12,44 @@ import { CRIT_CHANCE, CRIT_MOD, STAB_MOD } from './Constants'
 import { randInt } from './Utils'
 
 export class BattleCalculator {
-  /** Calculate damage from an attacker using a move on a defender. */
-
+  /**
+   * Calculate damage from an attacker using a move on a defender.
+   * @param attacker The attacking Pokemon
+   * @param defender The defending Pokemon
+   * @param move The move being used
+   * @param weather Current weather condition
+   * @param terrain Current terrain condition
+   * @param rng Random number generator for deterministic results
+   */
   static calculateDamage(
     attacker: Pokemon,
     defender: Pokemon,
     move: MoveData,
     weather: WeatherName,
-    terrain: TerrainName
+    terrain: TerrainName,
+    rng: () => number = Math.random
   ): number {
-=======
-  static calculateDamage(attacker: Pokemon, defender: Pokemon, move: MoveData): number {
-
     const levelFactor = (2 * attacker.level) / 5 + 2
     const attack = attacker.stats.attack
     const defense = defender.stats.defense
     let base = Math.floor(((levelFactor * move.power * attack) / defense) / 50) + 2
 
-    // Same-type attack bonus
     if (attacker.types.includes(move.type as TypeName)) {
       base = Math.floor(base * STAB_MOD)
     }
 
-    const typeMult = BattleCalculator.getTypeMultiplier(
-      move.type as TypeName,
-      defender.types
-    )
+    const typeMult = this.getTypeMultiplier(move.type as TypeName, defender.types)
     base = Math.floor(base * typeMult)
 
-
     base = Math.floor(
-      base * BattleCalculator.getWeatherTerrainMod(move.type as TypeName, weather, terrain)
+      base * this.getWeatherTerrainMod(move.type as TypeName, weather, terrain)
     )
 
-=======
-
-    // Critical hits
-    if (Math.random() < CRIT_CHANCE) {
+    if (rng() < CRIT_CHANCE) {
       base = Math.floor(base * CRIT_MOD)
     }
 
-    const random = randInt(85, 100) / 100
+    const random = randInt(85, 100, rng) / 100
     return Math.max(1, Math.floor(base * random))
   }
 
@@ -64,7 +61,6 @@ export class BattleCalculator {
       }
       return mult
     }, 1)
-
   }
 
   private static getWeatherTerrainMod(
@@ -87,6 +83,5 @@ export class BattleCalculator {
     if (terrain === TerrainName.Misty && type === 'Dragon') mod *= 0.5
 
     return mod
-=======
   }
 }

--- a/src/engine/BattleEngine.ts
+++ b/src/engine/BattleEngine.ts
@@ -7,6 +7,8 @@ import { BattleCalculator } from './BattleCalculator'
 import type { MoveData } from './Interfaces'
 import type { Pokemon } from './Pokemon'
 import { WEATHERS } from './Weather'
+import { MOVES } from './Moves'
+import { PokemonFactory } from './PokemonFactory'
 
 export class BattleEngine {
   state: BattleState
@@ -59,7 +61,6 @@ export class BattleEngine {
       this.state.weather,
       this.state.terrain
     )
-    let damage = BattleCalculator.calculateDamage(user, target, move)
     if (user.ability?.modifyDamage) {
       damage = user.ability.modifyDamage(user, move, target, damage)
     }
@@ -73,4 +74,28 @@ export class BattleEngine {
       weatherEffect.onResidual?.(mon)
     }
   }
+}
+
+// Simple demo when executed directly with ts-node
+if (process.argv[1] && process.argv[1].endsWith('BattleEngine.ts')) {
+  const pikachu = PokemonFactory.create(
+    'Pikachu',
+    { hp: 35, attack: 55, defense: 40, specialAttack: 50, specialDefense: 50, speed: 90 },
+    ['Electric']
+  )
+  const bulbasaur = PokemonFactory.create(
+    'Bulbasaur',
+    { hp: 45, attack: 49, defense: 49, specialAttack: 65, specialDefense: 65, speed: 45 },
+    ['Grass']
+  )
+  const engine = new BattleEngine(new BattleState([pikachu], [bulbasaur]))
+  console.log('Start demo battle!')
+  while (engine.state.active1 && engine.state.active2) {
+    engine.takeTurn(MOVES.Tackle, MOVES.Tackle)
+    console.log(
+      `Turn ${engine.state.turn}: Pikachu ${pikachu.currentHP} HP vs Bulbasaur ${bulbasaur.currentHP} HP`
+    )
+    if (pikachu.isFainted() || bulbasaur.isFainted()) engine.endBattle()
+  }
+  console.log('Battle finished.')
 }

--- a/src/engine/PokemonFactory.ts
+++ b/src/engine/PokemonFactory.ts
@@ -7,6 +7,19 @@ import type { Stats } from './Interfaces'
 import type { TypeName } from './Types'
 import { DEFAULT_LEVEL } from './Constants'
 
+const POKEDEX: { name: string; stats: Stats; types: TypeName[] }[] = [
+  {
+    name: 'Pikachu',
+    stats: { hp: 35, attack: 55, defense: 40, specialAttack: 50, specialDefense: 50, speed: 90 },
+    types: ['Electric'],
+  },
+  {
+    name: 'Bulbasaur',
+    stats: { hp: 45, attack: 49, defense: 49, specialAttack: 65, specialDefense: 65, speed: 45 },
+    types: ['Grass'],
+  },
+]
+
 export class PokemonFactory {
   /** Create a basic Pokemon with given stats. */
   static create(
@@ -18,17 +31,11 @@ export class PokemonFactory {
     return new Pokemon(name, stats, types, level)
   }
 
-  /** TODO: generate random legal Pokemon across generations. */
-  static random(): Pokemon {
-    const sampleStats: Stats = {
-      hp: 35,
-      attack: 55,
-      defense: 40,
-      specialAttack: 50,
-      specialDefense: 50,
-      speed: 90,
-    }
-    return new Pokemon('Eevee', sampleStats, ['Normal'])
+  /** Return a random Pokemon from the tiny built-in dex. */
+  static random(rng: () => number = Math.random): Pokemon {
+    const idx = Math.floor(rng() * POKEDEX.length)
+    const base = POKEDEX[idx]
+    return new Pokemon(base.name, base.stats, base.types)
   }
 }
 

--- a/src/engine/Utils.ts
+++ b/src/engine/Utils.ts
@@ -2,9 +2,26 @@
  * Miscellaneous helper functions for the battle engine.
  */
 
-/** Generate a random integer between min and max inclusive. */
-export function randInt(min: number, max: number): number {
-  return Math.floor(Math.random() * (max - min + 1)) + min
+/** Deterministic linear congruential generator for predictable randomness. */
+export class LCG {
+  private seed: number
+
+  constructor(seed = Date.now() % 2147483647) {
+    this.seed = seed
+  }
+
+  /**
+   * Generate the next pseudo random number in [0, 1).
+   */
+  next(): number {
+    this.seed = (this.seed * 48271) % 2147483647
+    return this.seed / 2147483647
+  }
+}
+
+/** Generate a random integer between min and max inclusive using provided RNG. */
+export function randInt(min: number, max: number, rng: () => number = Math.random): number {
+  return Math.floor(rng() * (max - min + 1)) + min
 }
 
 /** Shuffle an array in place. */


### PR DESCRIPTION
## Summary
- implement deterministic linear congruential generator
- clean up BattleCalculator and use RNG
- extend PokemonFactory with small Pokédex and random helper
- add a simple CLI demo in BattleEngine

## Testing
- `node src/engine/BattleEngine.ts`