### PR TITLE
Add basic AI module skeleton

### DIFF
--- a/src/ai/AdaptiveLearning.ts
+++ b/src/ai/AdaptiveLearning.ts
@@ -1,0 +1,41 @@
+/**
+ * Learns from battle outcomes and persists to data/ai-memory.json.
+ */
+
+import fs from 'fs'
+import path from 'path'
+
+const FILE = path.resolve('data', 'ai-memory.json')
+
+export interface Memory {
+  games: number
+  wins: number
+}
+
+export class AdaptiveLearning {
+  memory: Memory
+
+  constructor() {
+    if (fs.existsSync(FILE)) {
+      this.memory = JSON.parse(fs.readFileSync(FILE, 'utf8'))
+    } else {
+      this.memory = { games: 0, wins: 0 }
+    }
+  }
+
+  record(win: boolean): void {
+    this.memory.games++
+    if (win) this.memory.wins++
+    fs.mkdirSync(path.dirname(FILE), { recursive: true })
+    fs.writeFileSync(FILE, JSON.stringify(this.memory))
+  }
+}
+
+/* TESTS */
+if (process.argv[1] && process.argv[1].endsWith('AdaptiveLearning.ts')) {
+  const a = new AdaptiveLearning()
+  a.record(true)
+  console.assert(a.memory.games >= 1)
+  console.log('AdaptiveLearning tests passed')
+}
+

--- a/src/ai/BattleAI.ts
+++ b/src/ai/BattleAI.ts
@@ -1,0 +1,94 @@
+/**
+ * BattleAI orchestrates decision making during Pokemon battles.
+ * This is a simplified implementation demonstrating how evaluators
+ * could be composed together. It does not cover every battle rule.
+ */
+
+import { Pokemon } from '../engine/Pokemon'
+import type { MoveData } from '../engine/Interfaces'
+import { BattleEngine } from '../engine/BattleEngine'
+import { BattleState } from '../engine/BattleState'
+import { MOVES } from '../engine/Moves'
+import { PokemonFactory } from '../engine/PokemonFactory'
+
+import { MoveEvaluator } from './MoveEvaluator'
+import { SwitchEvaluator } from './SwitchEvaluator'
+import { PredictionEngine } from './PredictionEngine'
+import { RiskAssessment } from './RiskAssessment'
+import { GamePlan } from './GamePlan'
+
+/** Representation of using a move during a turn. */
+export interface MoveChoice {
+  type: 'move'
+  move: MoveData
+}
+
+/** Representation of switching to another Pokemon. */
+export interface SwitchChoice {
+  type: 'switch'
+  target: Pokemon
+}
+
+export type TurnChoice = MoveChoice | SwitchChoice
+
+/**
+ * Main AI class combining all sub systems.
+ */
+export class BattleAI {
+  private engine: BattleEngine
+  private moveEval: MoveEvaluator
+  private switchEval: SwitchEvaluator
+  private predictor: PredictionEngine
+  private risk: RiskAssessment
+  private plan: GamePlan
+
+  constructor(mySide: Pokemon[], enemySide: Pokemon[], format: string) {
+    const state = new BattleState(mySide, enemySide)
+    this.engine = new BattleEngine(state)
+    this.moveEval = new MoveEvaluator()
+    this.switchEval = new SwitchEvaluator()
+    this.predictor = new PredictionEngine()
+    this.risk = new RiskAssessment()
+    this.plan = new GamePlan(format)
+  }
+
+  /** Determine the best action for the current turn. */
+  decideTurn(): TurnChoice {
+    const me = this.engine.state.active1
+    const opp = this.engine.state.active2
+    if (!me || !opp) throw new Error('Battle not initialized')
+
+    const predictions = this.predictor.predictOpponent(this.engine.state)
+    const moveScore = this.moveEval.scoreMoves(me, opp, predictions)
+    const switchScore = this.switchEval.scoreSwitch(me, opp, this.engine.state)
+
+    const riskFactor = this.risk.evaluateRisk(this.engine.state, predictions)
+    this.plan.updatePlan(this.engine.state, riskFactor)
+
+    if (switchScore.score > moveScore.score * 1.1) {
+      return { type: 'switch', target: switchScore.best }
+    }
+    return { type: 'move', move: moveScore.best }
+  }
+}
+
+/* CLI demo showing the AI making basic decisions */
+if (process.argv[1] && process.argv[1].endsWith('BattleAI.ts')) {
+  const rng = Math.random
+  const pikachu = PokemonFactory.create(
+    'Pikachu',
+    { hp: 35, attack: 55, defense: 40, specialAttack: 50, specialDefense: 50, speed: 90 },
+    ['Electric']
+  )
+  const bulbasaur = PokemonFactory.create(
+    'Bulbasaur',
+    { hp: 45, attack: 49, defense: 49, specialAttack: 65, specialDefense: 65, speed: 45 },
+    ['Grass']
+  )
+  const ai = new BattleAI([pikachu], [bulbasaur], 'singles')
+  for (let turn = 1; turn <= 3; turn++) {
+    const choice = ai.decideTurn()
+    console.log(`Turn ${turn}:`, choice)
+  }
+}
+

--- a/src/ai/EloTracker.ts
+++ b/src/ai/EloTracker.ts
@@ -1,0 +1,28 @@
+/**
+ * Basic Elo tracker adjusting rating after battles.
+ */
+
+export class EloTracker {
+  rating: number
+  rd: number
+
+  constructor(rating = 1500, rd = 350) {
+    this.rating = rating
+    this.rd = rd
+  }
+
+  update(result: 1 | 0): void {
+    const k = 32
+    const expected = 1 / (1 + Math.pow(10, (-this.rating + 1500) / 400))
+    this.rating = this.rating + k * (result - expected)
+  }
+}
+
+/* TESTS */
+if (process.argv[1] && process.argv[1].endsWith('EloTracker.ts')) {
+  const elo = new EloTracker()
+  elo.update(1)
+  console.assert(elo.rating > 1500)
+  console.log('EloTracker tests passed')
+}
+

--- a/src/ai/GamePlan.ts
+++ b/src/ai/GamePlan.ts
@@ -1,0 +1,34 @@
+/**
+ * Maintains a basic battle game plan.
+ */
+
+import { BattleState } from '../engine/BattleState'
+
+export type Plan = 'hyper' | 'balanced' | 'stall'
+
+export class GamePlan {
+  private plan: Plan
+
+  constructor(format: string) {
+    this.plan = 'balanced'
+  }
+
+  updatePlan(state: BattleState, risk: number): void {
+    if (risk > 1.1) this.plan = 'stall'
+    else if (risk < 0.9) this.plan = 'hyper'
+    else this.plan = 'balanced'
+  }
+
+  get current(): Plan {
+    return this.plan
+  }
+}
+
+/* TESTS */
+if (process.argv[1] && process.argv[1].endsWith('GamePlan.ts')) {
+  const gp = new GamePlan('singles')
+  gp.updatePlan({} as BattleState, 1.2)
+  console.assert(gp.current === 'stall', 'plan updates')
+  console.log('GamePlan tests passed')
+}
+

--- a/src/ai/MetaKnowledge.ts
+++ b/src/ai/MetaKnowledge.ts
@@ -1,0 +1,27 @@
+/**
+ * Minimal curated meta information for common Pokemon sets.
+ */
+
+export interface MetaSet {
+  name: string
+  item: string
+  moves: string[]
+}
+
+const DATABASE: MetaSet[] = [
+  { name: 'Garchomp', item: 'Rocky Helmet', moves: ['Earthquake', 'Dragon Claw'] },
+  { name: 'Toxapex', item: 'Black Sludge', moves: ['Recover', 'Scald'] },
+]
+
+export class MetaKnowledge {
+  static lookup(name: string): MetaSet | undefined {
+    return DATABASE.find((m) => m.name === name)
+  }
+}
+
+/* TESTS */
+if (process.argv[1] && process.argv[1].endsWith('MetaKnowledge.ts')) {
+  console.assert(MetaKnowledge.lookup('Garchomp')?.item === 'Rocky Helmet')
+  console.log('MetaKnowledge tests passed')
+}
+

--- a/src/ai/MoveEvaluator.ts
+++ b/src/ai/MoveEvaluator.ts
@@ -1,0 +1,54 @@
+/**
+ * Evaluates potential moves for a Pokemon.
+ * Scores are based on estimated damage using the battle calculator.
+ */
+
+import type { Pokemon } from '../engine/Pokemon'
+import type { MoveData } from '../engine/Interfaces'
+import { BattleCalculator } from '../engine/BattleCalculator'
+import { WeatherName } from '../engine/Weather'
+import { TerrainName } from '../engine/Terrains'
+
+/** Result of evaluating all moves. */
+export interface MoveScore {
+  best: MoveData
+  score: number
+}
+
+export class MoveEvaluator {
+  /** Score all moves and pick the highest damage option. */
+  scoreMoves(attacker: Pokemon, defender: Pokemon, predictions: Record<string, number>): MoveScore {
+    const weather = WeatherName.None
+    const terrain = TerrainName.None
+    let best: MoveData | null = null
+    let bestScore = -Infinity
+    for (const name in attacker.moves || {}) {
+      const move: MoveData = (attacker as any).moves[name]
+      const dmg = BattleCalculator.calculateDamage(attacker, defender, move, weather, terrain, () => 0.5)
+      const score = dmg * (predictions[move.name] || 1)
+      if (score > bestScore) {
+        bestScore = score
+        best = move
+      }
+    }
+    // fallback to Tackle
+    const fallback = (attacker as any).moves?.Tackle ?? { name: 'Tackle', type: 'Normal', power: 40, accuracy: 100, pp: 35 }
+    return { best: best ?? fallback, score: bestScore }
+  }
+}
+
+/* TESTS */
+if (process.argv[1] && process.argv[1].endsWith('MoveEvaluator.ts')) {
+  const p1 = {
+    stats: { level: 50, hp: 40, attack: 55, defense: 30, specialAttack: 50, specialDefense: 40, speed: 60 },
+    moves: {
+      Tackle: { name: 'Tackle', type: 'Normal', power: 40, accuracy: 100, pp: 35 },
+    },
+  } as unknown as Pokemon
+  const p2 = { stats: { level: 50, hp: 50, attack: 40, defense: 40, specialAttack: 40, specialDefense: 40, speed: 40 } } as Pokemon
+  const evalr = new MoveEvaluator()
+  const res = evalr.scoreMoves(p1, p2, {})
+  console.assert(res.best.name === 'Tackle', 'should pick Tackle by default')
+  console.log('MoveEvaluator tests passed')
+}
+

--- a/src/ai/OpponentProfiler.ts
+++ b/src/ai/OpponentProfiler.ts
@@ -1,0 +1,31 @@
+/**
+ * Simple opponent behavior profiler.
+ */
+
+export type Profile = 'aggressive' | 'conservative'
+
+export class OpponentProfiler {
+  private aggression = 0
+  private turns = 0
+
+  record(attackUsed: boolean): void {
+    this.turns++
+    if (attackUsed) this.aggression++
+  }
+
+  get profile(): Profile {
+    if (this.turns === 0) return 'conservative'
+    return this.aggression / this.turns > 0.6 ? 'aggressive' : 'conservative'
+  }
+}
+
+/* TESTS */
+if (process.argv[1] && process.argv[1].endsWith('OpponentProfiler.ts')) {
+  const p = new OpponentProfiler()
+  p.record(true)
+  p.record(false)
+  p.record(true)
+  console.assert(p.profile === 'aggressive')
+  console.log('OpponentProfiler tests passed')
+}
+

--- a/src/ai/PredictionEngine.ts
+++ b/src/ai/PredictionEngine.ts
@@ -1,0 +1,40 @@
+/**
+ * Naive opponent action prediction using move history frequencies.
+ */
+
+import { BattleState } from '../engine/BattleState'
+
+export class PredictionEngine {
+  private history: Record<string, number> = {}
+
+  /** Record the opponent's last move for future predictions. */
+  record(move: string): void {
+    this.history[move] = (this.history[move] || 0) + 1
+  }
+
+  /**
+   * Predict probability distribution over opponent moves.
+   * @returns Map of move name to probability
+   */
+  predictOpponent(state: BattleState): Record<string, number> {
+    const total = Object.values(this.history).reduce((a, b) => a + b, 0)
+    if (total === 0) return {}
+    const dist: Record<string, number> = {}
+    for (const [move, count] of Object.entries(this.history)) {
+      dist[move] = count / total
+    }
+    return dist
+  }
+}
+
+/* TESTS */
+if (process.argv[1] && process.argv[1].endsWith('PredictionEngine.ts')) {
+  const engine = new PredictionEngine()
+  engine.record('Tackle')
+  engine.record('Tackle')
+  engine.record('Growl')
+  const dist = engine.predictOpponent({} as BattleState)
+  console.assert(Math.abs(dist.Tackle - 2 / 3) < 1e-6, 'Tackle prob')
+  console.log('PredictionEngine tests passed')
+}
+

--- a/src/ai/ReplayAnalyzer.ts
+++ b/src/ai/ReplayAnalyzer.ts
@@ -1,0 +1,25 @@
+/**
+ * Parses simplified Showdown replay JSON for statistics.
+ */
+
+import fs from 'fs'
+import { AdaptiveLearning } from './AdaptiveLearning'
+
+export class ReplayAnalyzer {
+  static analyze(pathToReplay: string): void {
+    const data = JSON.parse(fs.readFileSync(pathToReplay, 'utf8'))
+    const won = data.winner === data.player
+    const learner = new AdaptiveLearning()
+    learner.record(won)
+  }
+}
+
+/* TESTS */
+if (process.argv[1] && process.argv[1].endsWith('ReplayAnalyzer.ts')) {
+  const tmp = 'tmpReplay.json'
+  fs.writeFileSync(tmp, JSON.stringify({ player: 'me', winner: 'me' }))
+  ReplayAnalyzer.analyze(tmp)
+  fs.unlinkSync(tmp)
+  console.log('ReplayAnalyzer tests passed')
+}
+

--- a/src/ai/RiskAssessment.ts
+++ b/src/ai/RiskAssessment.ts
@@ -1,0 +1,23 @@
+/**
+ * Combines prediction output and battle state to gauge risk.
+ */
+
+import { BattleState } from '../engine/BattleState'
+
+export class RiskAssessment {
+  evaluateRisk(state: BattleState, predictions: Record<string, number>): number {
+    const oppHP = state.active2?.currentHP ?? 0
+    const myHP = state.active1?.currentHP ?? 0
+    const aggression = oppHP > myHP ? 1.2 : 0.8
+    const variance = Object.values(predictions).reduce((a, b) => a + b * (1 - b), 0)
+    return aggression * (1 + variance)
+  }
+}
+
+/* TESTS */
+if (process.argv[1] && process.argv[1].endsWith('RiskAssessment.ts')) {
+  const risk = new RiskAssessment().evaluateRisk({ active1: { currentHP: 30 }, active2: { currentHP: 40 } } as any, { Tackle: 1 })
+  console.assert(risk > 1, 'opponent ahead => risk > 1')
+  console.log('RiskAssessment tests passed')
+}
+

--- a/src/ai/SwitchEvaluator.ts
+++ b/src/ai/SwitchEvaluator.ts
@@ -1,0 +1,40 @@
+/**
+ * Evaluates whether switching Pokemon is favorable.
+ */
+
+import type { Pokemon } from '../engine/Pokemon'
+import { BattleState } from '../engine/BattleState'
+
+export interface SwitchScore {
+  best: Pokemon
+  score: number
+}
+
+export class SwitchEvaluator {
+  /** Simple heuristic: prefer the healthiest reserve Pokemon. */
+  scoreSwitch(active: Pokemon, opponent: Pokemon, state: BattleState): SwitchScore {
+    let best: Pokemon | null = null
+    let bestScore = -Infinity
+    for (const mon of state.team1) {
+      if (mon === active || mon.isFainted()) continue
+      const score = mon.currentHP
+      if (score > bestScore) {
+        bestScore = score
+        best = mon
+      }
+    }
+    return { best: best ?? active, score: bestScore }
+  }
+}
+
+/* TESTS */
+if (process.argv[1] && process.argv[1].endsWith('SwitchEvaluator.ts')) {
+  const p1 = { currentHP: 20, isFainted: () => false } as Pokemon
+  const p2 = { currentHP: 50, isFainted: () => false } as Pokemon
+  const state = new BattleState([p1, p2], [])
+  const evalr = new SwitchEvaluator()
+  const res = evalr.scoreSwitch(p1, {} as Pokemon, state)
+  console.assert(res.best === p2, 'should switch to healthiest')
+  console.log('SwitchEvaluator tests passed')
+}
+

--- a/src/ai/TeamBuilderAI.ts
+++ b/src/ai/TeamBuilderAI.ts
@@ -1,0 +1,23 @@
+/**
+ * Very small team builder using MetaKnowledge entries.
+ */
+
+import { PokemonFactory } from '../engine/PokemonFactory'
+import { MetaKnowledge } from './MetaKnowledge'
+
+export class TeamBuilderAI {
+  build(names: string[]): any[] {
+    return names.map((n) => {
+      const meta = MetaKnowledge.lookup(n)
+      return PokemonFactory.create(n, { hp: 50, attack: 50, defense: 50, specialAttack: 50, specialDefense: 50, speed: 50 }, ['Normal'], meta?.item)
+    })
+  }
+}
+
+/* TESTS */
+if (process.argv[1] && process.argv[1].endsWith('TeamBuilderAI.ts')) {
+  const team = new TeamBuilderAI().build(['Garchomp'])
+  console.assert(team[0].name === 'Garchomp')
+  console.log('TeamBuilderAI tests passed')
+}
+


### PR DESCRIPTION
## Summary
- introduce minimal `src/ai` folder with 12 TypeScript modules
- implement simple Move and Switch evaluators
- add naive prediction, risk, and game plan logic
- include extra utilities for meta knowledge, opponent profiling, team building, adaptive learning, replays and elo
- wire everything together in `BattleAI` with a demo

## Testing
- `git status --short`