### PR TITLE
Add basic analytics module

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview",
-    "dev:ui": "vite --root src/battle-ui"
+    "dev:ui": "vite --root src/battle-ui",
+    "dev:analytics": "vite --root src/analytics/reporting"
   },
   "keywords": [],
   "author": "",

--- a/src/analytics/core/MatchHistory.ts
+++ b/src/analytics/core/MatchHistory.ts
@@ -1,0 +1,26 @@
+import { getDB } from './idb';
+
+export interface MatchResult {
+  id?: number;
+  winner: string;
+  turns: number;
+  teams: string[];
+  MVP: string;
+  dateTimeISO: string;
+}
+
+const store = 'matches';
+
+export async function logBattle(result: MatchResult) {
+  const db = await getDB(store);
+  db.add(result);
+}
+
+export async function getHistory(limit = 20): Promise<MatchResult[]> {
+  const db = await getDB(store);
+  const req = db.getAll();
+  return new Promise((res, rej) => {
+    req.onsuccess = () => res(req.result.slice(-limit).reverse());
+    req.onerror = () => rej(req.error);
+  });
+}

--- a/src/analytics/core/PerformanceStats.ts
+++ b/src/analytics/core/PerformanceStats.ts
@@ -1,0 +1,17 @@
+import { getHistory } from './MatchHistory';
+
+export interface Stats {
+  total: number;
+  wins: number;
+  losses: number;
+  winRate: number;
+  avgTurns: number;
+}
+
+export async function getOverallStats(): Promise<Stats> {
+  const games = await getHistory(1000);
+  const wins = games.filter(g => g.winner === 'player').length;
+  const losses = games.length - wins;
+  const avgTurns = games.reduce((s, g) => s + g.turns, 0) / Math.max(1, games.length);
+  return { total: games.length, wins, losses, winRate: wins / Math.max(1, games.length), avgTurns };
+}

--- a/src/analytics/core/idb.ts
+++ b/src/analytics/core/idb.ts
@@ -1,0 +1,16 @@
+/** Simple IndexedDB helper */
+export function getDB(store: string): Promise<IDBObjectStore> {
+  return new Promise((resolve, reject) => {
+    const req = indexedDB.open('analytics');
+    req.onupgradeneeded = () => {
+      if (!req.result.objectStoreNames.contains(store)) {
+        req.result.createObjectStore(store, { keyPath: 'id', autoIncrement: true });
+      }
+    };
+    req.onerror = () => reject(req.error);
+    req.onsuccess = () => {
+      const tx = req.result.transaction(store, 'readwrite');
+      resolve(tx.objectStore(store));
+    };
+  });
+}

--- a/src/analytics/reporting/StatsDashboard.tsx
+++ b/src/analytics/reporting/StatsDashboard.tsx
@@ -1,0 +1,27 @@
+import React, { useEffect, useState } from 'react';
+import { LineChart, Line, XAxis, YAxis, Tooltip } from 'recharts';
+import { getOverallStats } from '../core/PerformanceStats';
+import { getHistory } from '../core/MatchHistory';
+
+export default function StatsDashboard() {
+  const [stats, setStats] = useState<any>(null);
+  const [history, setHistory] = useState<any[]>([]);
+
+  useEffect(() => {
+    getOverallStats().then(setStats);
+    getHistory(20).then(setHistory);
+  }, []);
+
+  if (!stats) return <div>Loading...</div>;
+  const data = history.map((h, i) => ({ name: i + 1, turns: h.turns }));
+
+  return (
+    <div>
+      <h2>Wins: {stats.wins} / {stats.total}</h2>
+      <LineChart width={300} height={150} data={data}>
+        <XAxis dataKey="name" /><YAxis /><Tooltip />
+        <Line type="monotone" dataKey="turns" stroke="#8884d8" />
+      </LineChart>
+    </div>
+  );
+}

--- a/src/analytics/reporting/index.html
+++ b/src/analytics/reporting/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Analytics Dashboard</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="./StatsDashboard.tsx"></script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- add a small analytics dashboard with match logging
- provide simple IndexedDB helper
- wire dev:analytics script

## Testing
- `npm run lint` *(fails: no lint script)*
- `npm test` *(fails: no tests)*