### PR TITLE
Add generation-specific Pokemon lists

### DIFF
--- a/src/config/PokemonGen1.json
+++ b/src/config/PokemonGen1.json
@@ -1,0 +1,25 @@
+{
+  "version": "1.0.0",
+  "pokemon": [
+    "Bulbasaur",
+    "Ivysaur",
+    "Venusaur",
+    "Charmander",
+    "Charmeleon",
+    "Charizard",
+    "Squirtle",
+    "Wartortle",
+    "Blastoise",
+    "Caterpie",
+    "Metapod",
+    "Butterfree",
+    "Weedle",
+    "Kakuna",
+    "Beedrill",
+    "Pidgey",
+    "Pidgeotto",
+    "Pidgeot",
+    "Rattata",
+    "Raticate"
+  ]
+}

--- a/src/config/PokemonGen2.json
+++ b/src/config/PokemonGen2.json
@@ -1,0 +1,25 @@
+{
+  "version": "1.0.0",
+  "pokemon": [
+    "Chikorita",
+    "Bayleef",
+    "Meganium",
+    "Cyndaquil",
+    "Quilava",
+    "Typhlosion",
+    "Totodile",
+    "Croconaw",
+    "Feraligatr",
+    "Sentret",
+    "Furret",
+    "Hoothoot",
+    "Noctowl",
+    "Ledyba",
+    "Ledian",
+    "Spinarak",
+    "Ariados",
+    "Crobat",
+    "Chinchou",
+    "Lanturn"
+  ]
+}

--- a/src/config/PokemonGen3.json
+++ b/src/config/PokemonGen3.json
@@ -1,0 +1,25 @@
+{
+  "version": "1.0.0",
+  "pokemon": [
+    "Treecko",
+    "Grovyle",
+    "Sceptile",
+    "Torchic",
+    "Combusken",
+    "Blaziken",
+    "Mudkip",
+    "Marshtomp",
+    "Swampert",
+    "Poochyena",
+    "Mightyena",
+    "Zigzagoon",
+    "Linoone",
+    "Wurmple",
+    "Silcoon",
+    "Beautifly",
+    "Cascoon",
+    "Dustox",
+    "Lotad",
+    "Lombre"
+  ]
+}

--- a/src/config/PokemonGen4.json
+++ b/src/config/PokemonGen4.json
@@ -1,0 +1,25 @@
+{
+  "version": "1.0.0",
+  "pokemon": [
+    "Turtwig",
+    "Grotle",
+    "Torterra",
+    "Chimchar",
+    "Monferno",
+    "Infernape",
+    "Piplup",
+    "Prinplup",
+    "Empoleon",
+    "Starly",
+    "Staravia",
+    "Staraptor",
+    "Bidoof",
+    "Bibarel",
+    "Kricketot",
+    "Kricketune",
+    "Shinx",
+    "Luxio",
+    "Luxray",
+    "Budew"
+  ]
+}

--- a/src/config/PokemonGen5.json
+++ b/src/config/PokemonGen5.json
@@ -1,0 +1,25 @@
+{
+  "version": "1.0.0",
+  "pokemon": [
+    "Victini",
+    "Snivy",
+    "Servine",
+    "Serperior",
+    "Tepig",
+    "Pignite",
+    "Emboar",
+    "Oshawott",
+    "Dewott",
+    "Samurott",
+    "Patrat",
+    "Watchog",
+    "Lillipup",
+    "Herdier",
+    "Stoutland",
+    "Purrloin",
+    "Liepard",
+    "Pansage",
+    "Simisage",
+    "Pansear"
+  ]
+}

--- a/src/config/PokemonGen6.json
+++ b/src/config/PokemonGen6.json
@@ -1,0 +1,25 @@
+{
+  "version": "1.0.0",
+  "pokemon": [
+    "Chespin",
+    "Quilladin",
+    "Chesnaught",
+    "Fennekin",
+    "Braixen",
+    "Delphox",
+    "Froakie",
+    "Frogadier",
+    "Greninja",
+    "Bunnelby",
+    "Diggersby",
+    "Fletchling",
+    "Fletchinder",
+    "Talonflame",
+    "Scatterbug",
+    "Spewpa",
+    "Vivillon",
+    "Litleo",
+    "Pyroar",
+    "Flabebe"
+  ]
+}

--- a/src/config/PokemonGen7.json
+++ b/src/config/PokemonGen7.json
@@ -1,0 +1,25 @@
+{
+  "version": "1.0.0",
+  "pokemon": [
+    "Rowlet",
+    "Dartrix",
+    "Decidueye",
+    "Litten",
+    "Torracat",
+    "Incineroar",
+    "Popplio",
+    "Brionne",
+    "Primarina",
+    "Pikipek",
+    "Trumbeak",
+    "Toucannon",
+    "Yungoos",
+    "Gumshoos",
+    "Grubbin",
+    "Charjabug",
+    "Vikavolt",
+    "Crabrawler",
+    "Crabominable",
+    "Oricorio"
+  ]
+}

--- a/src/config/PokemonGen8.json
+++ b/src/config/PokemonGen8.json
@@ -1,0 +1,25 @@
+{
+  "version": "1.0.0",
+  "pokemon": [
+    "Grookey",
+    "Thwackey",
+    "Rillaboom",
+    "Scorbunny",
+    "Raboot",
+    "Cinderace",
+    "Sobble",
+    "Drizzile",
+    "Inteleon",
+    "Skwovet",
+    "Greedent",
+    "Rookidee",
+    "Corvisquire",
+    "Corviknight",
+    "Blipbug",
+    "Dottler",
+    "Orbeetle",
+    "Nickit",
+    "Thievul",
+    "Gossifleur"
+  ]
+}

--- a/src/config/PokemonGen9.json
+++ b/src/config/PokemonGen9.json
@@ -1,0 +1,25 @@
+{
+  "version": "1.0.0",
+  "pokemon": [
+    "Sprigatito",
+    "Floragato",
+    "Meowscarada",
+    "Fuecoco",
+    "Crocalor",
+    "Skeledirge",
+    "Quaxly",
+    "Quaxwell",
+    "Quaquaval",
+    "Lechonk",
+    "Oinkologne",
+    "Tarountula",
+    "Spidops",
+    "Nymble",
+    "Lokix",
+    "Pawmi",
+    "Pawmo",
+    "Pawmot",
+    "Tandemaus",
+    "Maushold"
+  ]
+}


### PR DESCRIPTION
## Summary
- create new lists for the first 20 Pokémon of each generation
- add `PokemonGen1.json` through `PokemonGen9.json`

## Testing
- `jq '.pokemon | length' src/config/PokemonGen9.json`