### PR TITLE
Complete Gen 1 Pokémon data

### DIFF
--- a/src/config/PokemonGen1.json
+++ b/src/config/PokemonGen1.json
@@ -928,974 +928,1936 @@
         "Sand Veil"
       ],
       "weight": 0.8
+    },
+    {
+      "name": "Dugtrio",
+      "types": [
+        "Ground"
+      ],
+      "stats": {
+        "hp": 35,
+        "atk": 100,
+        "def": 50,
+        "spa": 50,
+        "spd": 70,
+        "spe": 120
+      },
+      "abilities": [
+        "Sand Veil",
+        "Arena Trap"
+      ],
+      "weight": 33.3
+    },
+    {
+      "name": "Meowth",
+      "types": [
+        "Normal"
+      ],
+      "stats": {
+        "hp": 40,
+        "atk": 45,
+        "def": 35,
+        "spa": 40,
+        "spd": 40,
+        "spe": 90
+      },
+      "abilities": [
+        "Pickup",
+        "Technician"
+      ],
+      "weight": 4.2
+    },
+    {
+      "name": "Persian",
+      "types": [
+        "Normal"
+      ],
+      "stats": {
+        "hp": 65,
+        "atk": 70,
+        "def": 60,
+        "spa": 65,
+        "spd": 65,
+        "spe": 115
+      },
+      "abilities": [
+        "Limber",
+        "Technician"
+      ],
+      "weight": 32.0
+    },
+    {
+      "name": "Psyduck",
+      "types": [
+        "Water"
+      ],
+      "stats": {
+        "hp": 50,
+        "atk": 52,
+        "def": 48,
+        "spa": 65,
+        "spd": 50,
+        "spe": 55
+      },
+      "abilities": [
+        "Damp",
+        "Cloud Nine"
+      ],
+      "weight": 19.6
+    },
+    {
+      "name": "Golduck",
+      "types": [
+        "Water"
+      ],
+      "stats": {
+        "hp": 80,
+        "atk": 82,
+        "def": 78,
+        "spa": 95,
+        "spd": 80,
+        "spe": 85
+      },
+      "abilities": [
+        "Damp",
+        "Cloud Nine"
+      ],
+      "weight": 76.6
+    },
+    {
+      "name": "Mankey",
+      "types": [
+        "Fighting"
+      ],
+      "stats": {
+        "hp": 40,
+        "atk": 80,
+        "def": 35,
+        "spa": 35,
+        "spd": 45,
+        "spe": 70
+      },
+      "abilities": [
+        "Vital Spirit",
+        "Anger Point"
+      ],
+      "weight": 28.0
+    },
+    {
+      "name": "Primeape",
+      "types": [
+        "Fighting"
+      ],
+      "stats": {
+        "hp": 65,
+        "atk": 105,
+        "def": 60,
+        "spa": 60,
+        "spd": 70,
+        "spe": 95
+      },
+      "abilities": [
+        "Vital Spirit",
+        "Anger Point"
+      ],
+      "weight": 32.0
+    },
+    {
+      "name": "Growlithe",
+      "types": [
+        "Fire"
+      ],
+      "stats": {
+        "hp": 55,
+        "atk": 70,
+        "def": 45,
+        "spa": 70,
+        "spd": 50,
+        "spe": 60
+      },
+      "abilities": [
+        "Intimidate",
+        "Flash Fire"
+      ],
+      "weight": 19.0
+    },
+    {
+      "name": "Arcanine",
+      "types": [
+        "Fire"
+      ],
+      "stats": {
+        "hp": 90,
+        "atk": 110,
+        "def": 80,
+        "spa": 100,
+        "spd": 80,
+        "spe": 95
+      },
+      "abilities": [
+        "Intimidate",
+        "Flash Fire"
+      ],
+      "weight": 155.0
+    },
+    {
+      "name": "Poliwag",
+      "types": [
+        "Water"
+      ],
+      "stats": {
+        "hp": 40,
+        "atk": 50,
+        "def": 40,
+        "spa": 40,
+        "spd": 40,
+        "spe": 90
+      },
+      "abilities": [
+        "Water Absorb",
+        "Damp"
+      ],
+      "weight": 12.4
+    },
+    {
+      "name": "Poliwhirl",
+      "types": [
+        "Water"
+      ],
+      "stats": {
+        "hp": 65,
+        "atk": 65,
+        "def": 65,
+        "spa": 50,
+        "spd": 50,
+        "spe": 90
+      },
+      "abilities": [
+        "Water Absorb",
+        "Damp"
+      ],
+      "weight": 20.0
+    },
+    {
+      "name": "Poliwrath",
+      "types": [
+        "Water",
+        "Fighting"
+      ],
+      "stats": {
+        "hp": 90,
+        "atk": 95,
+        "def": 95,
+        "spa": 70,
+        "spd": 90,
+        "spe": 70
+      },
+      "abilities": [
+        "Water Absorb",
+        "Damp"
+      ],
+      "weight": 54.0
+    },
+    {
+      "name": "Abra",
+      "types": [
+        "Psychic"
+      ],
+      "stats": {
+        "hp": 25,
+        "atk": 20,
+        "def": 15,
+        "spa": 105,
+        "spd": 55,
+        "spe": 90
+      },
+      "abilities": [
+        "Synchronize",
+        "Inner Focus"
+      ],
+      "weight": 19.5
+    },
+    {
+      "name": "Kadabra",
+      "types": [
+        "Psychic"
+      ],
+      "stats": {
+        "hp": 40,
+        "atk": 35,
+        "def": 30,
+        "spa": 120,
+        "spd": 70,
+        "spe": 105
+      },
+      "abilities": [
+        "Synchronize",
+        "Inner Focus"
+      ],
+      "weight": 56.5
+    },
+    {
+      "name": "Alakazam",
+      "types": [
+        "Psychic"
+      ],
+      "stats": {
+        "hp": 55,
+        "atk": 50,
+        "def": 45,
+        "spa": 135,
+        "spd": 95,
+        "spe": 120
+      },
+      "abilities": [
+        "Synchronize",
+        "Inner Focus"
+      ],
+      "weight": 48.0
+    },
+    {
+      "name": "Machop",
+      "types": [
+        "Fighting"
+      ],
+      "stats": {
+        "hp": 70,
+        "atk": 80,
+        "def": 50,
+        "spa": 35,
+        "spd": 35,
+        "spe": 35
+      },
+      "abilities": [
+        "Guts",
+        "No Guard"
+      ],
+      "weight": 19.5
+    },
+    {
+      "name": "Machoke",
+      "types": [
+        "Fighting"
+      ],
+      "stats": {
+        "hp": 80,
+        "atk": 100,
+        "def": 70,
+        "spa": 50,
+        "spd": 60,
+        "spe": 45
+      },
+      "abilities": [
+        "Guts",
+        "No Guard"
+      ],
+      "weight": 70.5
+    },
+    {
+      "name": "Machamp",
+      "types": [
+        "Fighting"
+      ],
+      "stats": {
+        "hp": 90,
+        "atk": 130,
+        "def": 80,
+        "spa": 65,
+        "spd": 85,
+        "spe": 55
+      },
+      "abilities": [
+        "Guts",
+        "No Guard"
+      ],
+      "weight": 130.0
+    },
+    {
+      "name": "Bellsprout",
+      "types": [
+        "Grass",
+        "Poison"
+      ],
+      "stats": {
+        "hp": 50,
+        "atk": 75,
+        "def": 35,
+        "spa": 70,
+        "spd": 30,
+        "spe": 40
+      },
+      "abilities": [
+        "Chlorophyll"
+      ],
+      "weight": 4.0
+    },
+    {
+      "name": "Weepinbell",
+      "types": [
+        "Grass",
+        "Poison"
+      ],
+      "stats": {
+        "hp": 65,
+        "atk": 90,
+        "def": 50,
+        "spa": 85,
+        "spd": 45,
+        "spe": 55
+      },
+      "abilities": [
+        "Chlorophyll"
+      ],
+      "weight": 6.4
+    },
+    {
+      "name": "Victreebel",
+      "types": [
+        "Grass",
+        "Poison"
+      ],
+      "stats": {
+        "hp": 80,
+        "atk": 105,
+        "def": 65,
+        "spa": 100,
+        "spd": 70,
+        "spe": 70
+      },
+      "abilities": [
+        "Chlorophyll"
+      ],
+      "weight": 15.5
+    },
+    {
+      "name": "Tentacool",
+      "types": [
+        "Water",
+        "Poison"
+      ],
+      "stats": {
+        "hp": 40,
+        "atk": 40,
+        "def": 35,
+        "spa": 50,
+        "spd": 100,
+        "spe": 70
+      },
+      "abilities": [
+        "Clear Body",
+        "Liquid Ooze"
+      ],
+      "weight": 45.5
+    },
+    {
+      "name": "Tentacruel",
+      "types": [
+        "Water",
+        "Poison"
+      ],
+      "stats": {
+        "hp": 80,
+        "atk": 70,
+        "def": 65,
+        "spa": 80,
+        "spd": 120,
+        "spe": 100
+      },
+      "abilities": [
+        "Clear Body",
+        "Liquid Ooze"
+      ],
+      "weight": 55.0
+    },
+    {
+      "name": "Geodude",
+      "types": [
+        "Rock",
+        "Ground"
+      ],
+      "stats": {
+        "hp": 40,
+        "atk": 80,
+        "def": 100,
+        "spa": 30,
+        "spd": 30,
+        "spe": 20
+      },
+      "abilities": [
+        "Rock Head",
+        "Sturdy"
+      ],
+      "weight": 20.0
+    },
+    {
+      "name": "Graveler",
+      "types": [
+        "Rock",
+        "Ground"
+      ],
+      "stats": {
+        "hp": 55,
+        "atk": 95,
+        "def": 115,
+        "spa": 45,
+        "spd": 45,
+        "spe": 35
+      },
+      "abilities": [
+        "Rock Head",
+        "Sturdy"
+      ],
+      "weight": 105.0
+    },
+    {
+      "name": "Golem",
+      "types": [
+        "Rock",
+        "Ground"
+      ],
+      "stats": {
+        "hp": 80,
+        "atk": 120,
+        "def": 130,
+        "spa": 55,
+        "spd": 65,
+        "spe": 45
+      },
+      "abilities": [
+        "Rock Head",
+        "Sturdy"
+      ],
+      "weight": 300.0
+    },
+    {
+      "name": "Ponyta",
+      "types": [
+        "Fire"
+      ],
+      "stats": {
+        "hp": 50,
+        "atk": 85,
+        "def": 55,
+        "spa": 65,
+        "spd": 65,
+        "spe": 90
+      },
+      "abilities": [
+        "Run Away",
+        "Flash Fire"
+      ],
+      "weight": 30.0
+    },
+    {
+      "name": "Rapidash",
+      "types": [
+        "Fire"
+      ],
+      "stats": {
+        "hp": 65,
+        "atk": 100,
+        "def": 70,
+        "spa": 80,
+        "spd": 80,
+        "spe": 105
+      },
+      "abilities": [
+        "Run Away",
+        "Flash Fire"
+      ],
+      "weight": 95.0
+    },
+    {
+      "name": "Slowpoke",
+      "types": [
+        "Water",
+        "Psychic"
+      ],
+      "stats": {
+        "hp": 90,
+        "atk": 65,
+        "def": 65,
+        "spa": 40,
+        "spd": 40,
+        "spe": 15
+      },
+      "abilities": [
+        "Oblivious",
+        "Own Tempo"
+      ],
+      "weight": 36.0
+    },
+    {
+      "name": "Slowbro",
+      "types": [
+        "Water",
+        "Psychic"
+      ],
+      "stats": {
+        "hp": 95,
+        "atk": 75,
+        "def": 110,
+        "spa": 100,
+        "spd": 80,
+        "spe": 30
+      },
+      "abilities": [
+        "Oblivious",
+        "Own Tempo"
+      ],
+      "weight": 78.5
+    },
+    {
+      "name": "Magnemite",
+      "types": [
+        "Electric",
+        "Steel"
+      ],
+      "stats": {
+        "hp": 25,
+        "atk": 35,
+        "def": 70,
+        "spa": 95,
+        "spd": 55,
+        "spe": 45
+      },
+      "abilities": [
+        "Magnet Pull",
+        "Sturdy"
+      ],
+      "weight": 6.0
+    },
+    {
+      "name": "Magneton",
+      "types": [
+        "Electric",
+        "Steel"
+      ],
+      "stats": {
+        "hp": 50,
+        "atk": 60,
+        "def": 95,
+        "spa": 120,
+        "spd": 70,
+        "spe": 70
+      },
+      "abilities": [
+        "Magnet Pull",
+        "Sturdy"
+      ],
+      "weight": 60.0
+    },
+    {
+      "name": "Farfetch'd",
+      "types": [
+        "Normal",
+        "Flying"
+      ],
+      "stats": {
+        "hp": 52,
+        "atk": 90,
+        "def": 55,
+        "spa": 58,
+        "spd": 62,
+        "spe": 60
+      },
+      "abilities": [
+        "Keen Eye",
+        "Inner Focus"
+      ],
+      "weight": 15.0
+    },
+    {
+      "name": "Doduo",
+      "types": [
+        "Normal",
+        "Flying"
+      ],
+      "stats": {
+        "hp": 35,
+        "atk": 85,
+        "def": 45,
+        "spa": 35,
+        "spd": 35,
+        "spe": 75
+      },
+      "abilities": [
+        "Run Away",
+        "Early Bird"
+      ],
+      "weight": 39.2
+    },
+    {
+      "name": "Dodrio",
+      "types": [
+        "Normal",
+        "Flying"
+      ],
+      "stats": {
+        "hp": 60,
+        "atk": 110,
+        "def": 70,
+        "spa": 60,
+        "spd": 60,
+        "spe": 110
+      },
+      "abilities": [
+        "Run Away",
+        "Early Bird"
+      ],
+      "weight": 85.2
+    },
+    {
+      "name": "Seel",
+      "types": [
+        "Water"
+      ],
+      "stats": {
+        "hp": 65,
+        "atk": 45,
+        "def": 55,
+        "spa": 45,
+        "spd": 70,
+        "spe": 45
+      },
+      "abilities": [
+        "Thick Fat",
+        "Hydration"
+      ],
+      "weight": 90.0
+    },
+    {
+      "name": "Dewgong",
+      "types": [
+        "Water",
+        "Ice"
+      ],
+      "stats": {
+        "hp": 90,
+        "atk": 70,
+        "def": 80,
+        "spa": 70,
+        "spd": 95,
+        "spe": 70
+      },
+      "abilities": [
+        "Thick Fat",
+        "Hydration"
+      ],
+      "weight": 120.0
+    },
+    {
+      "name": "Grimer",
+      "types": [
+        "Poison"
+      ],
+      "stats": {
+        "hp": 80,
+        "atk": 80,
+        "def": 50,
+        "spa": 40,
+        "spd": 50,
+        "spe": 25
+      },
+      "abilities": [
+        "Stench",
+        "Sticky Hold"
+      ],
+      "weight": 30.0
+    },
+    {
+      "name": "Muk",
+      "types": [
+        "Poison"
+      ],
+      "stats": {
+        "hp": 105,
+        "atk": 105,
+        "def": 75,
+        "spa": 65,
+        "spd": 100,
+        "spe": 50
+      },
+      "abilities": [
+        "Stench",
+        "Sticky Hold"
+      ],
+      "weight": 30.0
+    },
+    {
+      "name": "Shellder",
+      "types": [
+        "Water"
+      ],
+      "stats": {
+        "hp": 30,
+        "atk": 65,
+        "def": 100,
+        "spa": 45,
+        "spd": 25,
+        "spe": 40
+      },
+      "abilities": [
+        "Shell Armor",
+        "Skill Link"
+      ],
+      "weight": 4.0
+    },
+    {
+      "name": "Cloyster",
+      "types": [
+        "Water",
+        "Ice"
+      ],
+      "stats": {
+        "hp": 50,
+        "atk": 95,
+        "def": 180,
+        "spa": 85,
+        "spd": 45,
+        "spe": 70
+      },
+      "abilities": [
+        "Shell Armor",
+        "Skill Link"
+      ],
+      "weight": 132.5
+    },
+    {
+      "name": "Gastly",
+      "types": [
+        "Ghost",
+        "Poison"
+      ],
+      "stats": {
+        "hp": 30,
+        "atk": 35,
+        "def": 30,
+        "spa": 100,
+        "spd": 35,
+        "spe": 80
+      },
+      "abilities": [
+        "Levitate"
+      ],
+      "weight": 0.1
+    },
+    {
+      "name": "Haunter",
+      "types": [
+        "Ghost",
+        "Poison"
+      ],
+      "stats": {
+        "hp": 45,
+        "atk": 50,
+        "def": 45,
+        "spa": 115,
+        "spd": 55,
+        "spe": 95
+      },
+      "abilities": [
+        "Levitate"
+      ],
+      "weight": 0.1
+    },
+    {
+      "name": "Gengar",
+      "types": [
+        "Ghost",
+        "Poison"
+      ],
+      "stats": {
+        "hp": 60,
+        "atk": 65,
+        "def": 60,
+        "spa": 130,
+        "spd": 75,
+        "spe": 110
+      },
+      "abilities": [
+        "Cursed Body"
+      ],
+      "weight": 40.5
+    },
+    {
+      "name": "Onix",
+      "types": [
+        "Rock",
+        "Ground"
+      ],
+      "stats": {
+        "hp": 35,
+        "atk": 45,
+        "def": 160,
+        "spa": 30,
+        "spd": 45,
+        "spe": 70
+      },
+      "abilities": [
+        "Rock Head",
+        "Sturdy"
+      ],
+      "weight": 210.0
+    },
+    {
+      "name": "Drowzee",
+      "types": [
+        "Psychic"
+      ],
+      "stats": {
+        "hp": 60,
+        "atk": 48,
+        "def": 45,
+        "spa": 43,
+        "spd": 90,
+        "spe": 42
+      },
+      "abilities": [
+        "Insomnia",
+        "Forewarn"
+      ],
+      "weight": 32.4
+    },
+    {
+      "name": "Hypno",
+      "types": [
+        "Psychic"
+      ],
+      "stats": {
+        "hp": 85,
+        "atk": 73,
+        "def": 70,
+        "spa": 73,
+        "spd": 115,
+        "spe": 67
+      },
+      "abilities": [
+        "Insomnia",
+        "Forewarn"
+      ],
+      "weight": 75.6
+    },
+    {
+      "name": "Krabby",
+      "types": [
+        "Water"
+      ],
+      "stats": {
+        "hp": 30,
+        "atk": 105,
+        "def": 90,
+        "spa": 25,
+        "spd": 25,
+        "spe": 50
+      },
+      "abilities": [
+        "Hyper Cutter",
+        "Shell Armor"
+      ],
+      "weight": 6.5
+    },
+    {
+      "name": "Kingler",
+      "types": [
+        "Water"
+      ],
+      "stats": {
+        "hp": 55,
+        "atk": 130,
+        "def": 115,
+        "spa": 50,
+        "spd": 50,
+        "spe": 75
+      },
+      "abilities": [
+        "Hyper Cutter",
+        "Shell Armor"
+      ],
+      "weight": 60.0
+    },
+    {
+      "name": "Voltorb",
+      "types": [
+        "Electric"
+      ],
+      "stats": {
+        "hp": 40,
+        "atk": 30,
+        "def": 50,
+        "spa": 55,
+        "spd": 55,
+        "spe": 100
+      },
+      "abilities": [
+        "Soundproof",
+        "Static"
+      ],
+      "weight": 10.4
+    },
+    {
+      "name": "Electrode",
+      "types": [
+        "Electric"
+      ],
+      "stats": {
+        "hp": 60,
+        "atk": 50,
+        "def": 70,
+        "spa": 80,
+        "spd": 80,
+        "spe": 150
+      },
+      "abilities": [
+        "Soundproof",
+        "Static"
+      ],
+      "weight": 66.6
+    },
+    {
+      "name": "Exeggcute",
+      "types": [
+        "Grass",
+        "Psychic"
+      ],
+      "stats": {
+        "hp": 60,
+        "atk": 40,
+        "def": 80,
+        "spa": 60,
+        "spd": 45,
+        "spe": 40
+      },
+      "abilities": [
+        "Chlorophyll"
+      ],
+      "weight": 2.5
+    },
+    {
+      "name": "Exeggutor",
+      "types": [
+        "Grass",
+        "Psychic"
+      ],
+      "stats": {
+        "hp": 95,
+        "atk": 95,
+        "def": 85,
+        "spa": 125,
+        "spd": 75,
+        "spe": 55
+      },
+      "abilities": [
+        "Chlorophyll"
+      ],
+      "weight": 120.0
+    },
+    {
+      "name": "Cubone",
+      "types": [
+        "Ground"
+      ],
+      "stats": {
+        "hp": 50,
+        "atk": 50,
+        "def": 95,
+        "spa": 40,
+        "spd": 50,
+        "spe": 35
+      },
+      "abilities": [
+        "Rock Head",
+        "Lightning Rod"
+      ],
+      "weight": 6.5
+    },
+    {
+      "name": "Marowak",
+      "types": [
+        "Ground"
+      ],
+      "stats": {
+        "hp": 60,
+        "atk": 80,
+        "def": 110,
+        "spa": 50,
+        "spd": 80,
+        "spe": 45
+      },
+      "abilities": [
+        "Rock Head",
+        "Lightning Rod"
+      ],
+      "weight": 45.0
+    },
+    {
+      "name": "Hitmonlee",
+      "types": [
+        "Fighting"
+      ],
+      "stats": {
+        "hp": 50,
+        "atk": 120,
+        "def": 53,
+        "spa": 35,
+        "spd": 110,
+        "spe": 87
+      },
+      "abilities": [
+        "Limber"
+      ],
+      "weight": 49.8
+    },
+    {
+      "name": "Hitmonchan",
+      "types": [
+        "Fighting"
+      ],
+      "stats": {
+        "hp": 50,
+        "atk": 105,
+        "def": 79,
+        "spa": 35,
+        "spd": 110,
+        "spe": 76
+      },
+      "abilities": [
+        "Keen Eye"
+      ],
+      "weight": 50.2
+    },
+    {
+      "name": "Lickitung",
+      "types": [
+        "Normal"
+      ],
+      "stats": {
+        "hp": 90,
+        "atk": 55,
+        "def": 75,
+        "spa": 60,
+        "spd": 75,
+        "spe": 30
+      },
+      "abilities": [
+        "Own Tempo",
+        "Oblivious"
+      ],
+      "weight": 65.5
+    },
+    {
+      "name": "Koffing",
+      "types": [
+        "Poison"
+      ],
+      "stats": {
+        "hp": 40,
+        "atk": 65,
+        "def": 95,
+        "spa": 60,
+        "spd": 45,
+        "spe": 35
+      },
+      "abilities": [
+        "Levitate"
+      ],
+      "weight": 1.0
+    },
+    {
+      "name": "Weezing",
+      "types": [
+        "Poison"
+      ],
+      "stats": {
+        "hp": 65,
+        "atk": 90,
+        "def": 120,
+        "spa": 85,
+        "spd": 70,
+        "spe": 60
+      },
+      "abilities": [
+        "Levitate"
+      ],
+      "weight": 9.5
+    },
+    {
+      "name": "Rhyhorn",
+      "types": [
+        "Ground",
+        "Rock"
+      ],
+      "stats": {
+        "hp": 80,
+        "atk": 85,
+        "def": 95,
+        "spa": 30,
+        "spd": 30,
+        "spe": 25
+      },
+      "abilities": [
+        "Lightning Rod",
+        "Rock Head"
+      ],
+      "weight": 115.0
+    },
+    {
+      "name": "Rhydon",
+      "types": [
+        "Ground",
+        "Rock"
+      ],
+      "stats": {
+        "hp": 105,
+        "atk": 130,
+        "def": 120,
+        "spa": 45,
+        "spd": 45,
+        "spe": 40
+      },
+      "abilities": [
+        "Lightning Rod",
+        "Rock Head"
+      ],
+      "weight": 120.0
+    },
+    {
+      "name": "Chansey",
+      "types": [
+        "Normal"
+      ],
+      "stats": {
+        "hp": 250,
+        "atk": 5,
+        "def": 5,
+        "spa": 35,
+        "spd": 105,
+        "spe": 50
+      },
+      "abilities": [
+        "Natural Cure",
+        "Serene Grace"
+      ],
+      "weight": 34.6
+    },
+    {
+      "name": "Tangela",
+      "types": [
+        "Grass"
+      ],
+      "stats": {
+        "hp": 65,
+        "atk": 55,
+        "def": 115,
+        "spa": 100,
+        "spd": 40,
+        "spe": 60
+      },
+      "abilities": [
+        "Chlorophyll"
+      ],
+      "weight": 35.0
+    },
+    {
+      "name": "Kangaskhan",
+      "types": [
+        "Normal"
+      ],
+      "stats": {
+        "hp": 105,
+        "atk": 95,
+        "def": 80,
+        "spa": 40,
+        "spd": 80,
+        "spe": 90
+      },
+      "abilities": [
+        "Early Bird"
+      ],
+      "weight": 80.0
+    },
+    {
+      "name": "Horsea",
+      "types": [
+        "Water"
+      ],
+      "stats": {
+        "hp": 30,
+        "atk": 40,
+        "def": 70,
+        "spa": 70,
+        "spd": 25,
+        "spe": 60
+      },
+      "abilities": [
+        "Swift Swim"
+      ],
+      "weight": 8.0
+    },
+    {
+      "name": "Seadra",
+      "types": [
+        "Water"
+      ],
+      "stats": {
+        "hp": 55,
+        "atk": 65,
+        "def": 95,
+        "spa": 95,
+        "spd": 45,
+        "spe": 85
+      },
+      "abilities": [
+        "Poison Point",
+        "Sniper"
+      ],
+      "weight": 25.0
+    },
+    {
+      "name": "Goldeen",
+      "types": [
+        "Water"
+      ],
+      "stats": {
+        "hp": 45,
+        "atk": 67,
+        "def": 60,
+        "spa": 35,
+        "spd": 50,
+        "spe": 63
+      },
+      "abilities": [
+        "Swift Swim",
+        "Water Veil"
+      ],
+      "weight": 15.0
+    },
+    {
+      "name": "Seaking",
+      "types": [
+        "Water"
+      ],
+      "stats": {
+        "hp": 80,
+        "atk": 92,
+        "def": 65,
+        "spa": 65,
+        "spd": 80,
+        "spe": 68
+      },
+      "abilities": [
+        "Swift Swim",
+        "Water Veil"
+      ],
+      "weight": 39.0
+    },
+    {
+      "name": "Staryu",
+      "types": [
+        "Water"
+      ],
+      "stats": {
+        "hp": 30,
+        "atk": 45,
+        "def": 55,
+        "spa": 70,
+        "spd": 55,
+        "spe": 85
+      },
+      "abilities": [
+        "Illuminate",
+        "Natural Cure"
+      ],
+      "weight": 34.5
+    },
+    {
+      "name": "Starmie",
+      "types": [
+        "Water",
+        "Psychic"
+      ],
+      "stats": {
+        "hp": 60,
+        "atk": 75,
+        "def": 85,
+        "spa": 100,
+        "spd": 85,
+        "spe": 115
+      },
+      "abilities": [
+        "Illuminate",
+        "Natural Cure"
+      ],
+      "weight": 80.0
+    },
+    {
+      "name": "Mr. Mime",
+      "types": [
+        "Psychic",
+        "Fairy"
+      ],
+      "stats": {
+        "hp": 40,
+        "atk": 45,
+        "def": 65,
+        "spa": 100,
+        "spd": 120,
+        "spe": 90
+      },
+      "abilities": [
+        "Soundproof",
+        "Filter"
+      ],
+      "weight": 54.5
+    },
+    {
+      "name": "Scyther",
+      "types": [
+        "Bug",
+        "Flying"
+      ],
+      "stats": {
+        "hp": 70,
+        "atk": 110,
+        "def": 80,
+        "spa": 55,
+        "spd": 80,
+        "spe": 105
+      },
+      "abilities": [
+        "Swarm",
+        "Technician"
+      ],
+      "weight": 56.0
+    },
+    {
+      "name": "Jynx",
+      "types": [
+        "Ice",
+        "Psychic"
+      ],
+      "stats": {
+        "hp": 65,
+        "atk": 50,
+        "def": 35,
+        "spa": 115,
+        "spd": 95,
+        "spe": 95
+      },
+      "abilities": [
+        "Oblivious",
+        "Forewarn"
+      ],
+      "weight": 40.6
+    },
+    {
+      "name": "Electabuzz",
+      "types": [
+        "Electric"
+      ],
+      "stats": {
+        "hp": 65,
+        "atk": 83,
+        "def": 57,
+        "spa": 95,
+        "spd": 85,
+        "spe": 105
+      },
+      "abilities": [
+        "Static"
+      ],
+      "weight": 30.0
+    },
+    {
+      "name": "Magmar",
+      "types": [
+        "Fire"
+      ],
+      "stats": {
+        "hp": 65,
+        "atk": 95,
+        "def": 57,
+        "spa": 100,
+        "spd": 85,
+        "spe": 93
+      },
+      "abilities": [
+        "Flame Body"
+      ],
+      "weight": 44.5
+    },
+    {
+      "name": "Pinsir",
+      "types": [
+        "Bug"
+      ],
+      "stats": {
+        "hp": 65,
+        "atk": 125,
+        "def": 100,
+        "spa": 55,
+        "spd": 70,
+        "spe": 85
+      },
+      "abilities": [
+        "Hyper Cutter",
+        "Mold Breaker"
+      ],
+      "weight": 55.0
+    },
+    {
+      "name": "Tauros",
+      "types": [
+        "Normal"
+      ],
+      "stats": {
+        "hp": 75,
+        "atk": 100,
+        "def": 95,
+        "spa": 40,
+        "spd": 70,
+        "spe": 110
+      },
+      "abilities": [
+        "Intimidate",
+        "Anger Point"
+      ],
+      "weight": 88.4
+    },
+    {
+      "name": "Magikarp",
+      "types": [
+        "Water"
+      ],
+      "stats": {
+        "hp": 20,
+        "atk": 10,
+        "def": 55,
+        "spa": 15,
+        "spd": 20,
+        "spe": 80
+      },
+      "abilities": [
+        "Swift Swim"
+      ],
+      "weight": 10.0
+    },
+    {
+      "name": "Gyarados",
+      "types": [
+        "Water",
+        "Flying"
+      ],
+      "stats": {
+        "hp": 95,
+        "atk": 125,
+        "def": 79,
+        "spa": 60,
+        "spd": 100,
+        "spe": 81
+      },
+      "abilities": [
+        "Intimidate",
+        "Moxie"
+      ],
+      "weight": 235.0
+    },
+    {
+      "name": "Lapras",
+      "types": [
+        "Water",
+        "Ice"
+      ],
+      "stats": {
+        "hp": 130,
+        "atk": 85,
+        "def": 80,
+        "spa": 85,
+        "spd": 95,
+        "spe": 60
+      },
+      "abilities": [
+        "Water Absorb",
+        "Shell Armor"
+      ],
+      "weight": 220.0
+    },
+    {
+      "name": "Ditto",
+      "types": [
+        "Normal"
+      ],
+      "stats": {
+        "hp": 48,
+        "atk": 48,
+        "def": 48,
+        "spa": 48,
+        "spd": 48,
+        "spe": 48
+      },
+      "abilities": [
+        "Limber"
+      ],
+      "weight": 4.0
+    },
+    {
+      "name": "Eevee",
+      "types": [
+        "Normal"
+      ],
+      "stats": {
+        "hp": 55,
+        "atk": 55,
+        "def": 50,
+        "spa": 45,
+        "spd": 65,
+        "spe": 55
+      },
+      "abilities": [
+        "Run Away",
+        "Adaptability"
+      ],
+      "weight": 6.5
+    },
+    {
+      "name": "Vaporeon",
+      "types": [
+        "Water"
+      ],
+      "stats": {
+        "hp": 130,
+        "atk": 65,
+        "def": 60,
+        "spa": 110,
+        "spd": 95,
+        "spe": 65
+      },
+      "abilities": [
+        "Water Absorb"
+      ],
+      "weight": 29.0
+    },
+    {
+      "name": "Jolteon",
+      "types": [
+        "Electric"
+      ],
+      "stats": {
+        "hp": 65,
+        "atk": 65,
+        "def": 60,
+        "spa": 110,
+        "spd": 95,
+        "spe": 130
+      },
+      "abilities": [
+        "Volt Absorb"
+      ],
+      "weight": 24.5
+    },
+    {
+      "name": "Flareon",
+      "types": [
+        "Fire"
+      ],
+      "stats": {
+        "hp": 65,
+        "atk": 130,
+        "def": 60,
+        "spa": 95,
+        "spd": 110,
+        "spe": 65
+      },
+      "abilities": [
+        "Flash Fire"
+      ],
+      "weight": 25.0
+    },
+    {
+      "name": "Porygon",
+      "types": [
+        "Normal"
+      ],
+      "stats": {
+        "hp": 65,
+        "atk": 60,
+        "def": 70,
+        "spa": 85,
+        "spd": 75,
+        "spe": 40
+      },
+      "abilities": [
+        "Trace",
+        "Download"
+      ],
+      "weight": 36.5
+    },
+    {
+      "name": "Omanyte",
+      "types": [
+        "Rock",
+        "Water"
+      ],
+      "stats": {
+        "hp": 35,
+        "atk": 40,
+        "def": 100,
+        "spa": 90,
+        "spd": 55,
+        "spe": 35
+      },
+      "abilities": [
+        "Swift Swim",
+        "Shell Armor"
+      ],
+      "weight": 7.5
+    },
+    {
+      "name": "Omastar",
+      "types": [
+        "Rock",
+        "Water"
+      ],
+      "stats": {
+        "hp": 70,
+        "atk": 60,
+        "def": 125,
+        "spa": 115,
+        "spd": 70,
+        "spe": 55
+      },
+      "abilities": [
+        "Swift Swim",
+        "Shell Armor"
+      ],
+      "weight": 35.0
+    },
+    {
+      "name": "Kabuto",
+      "types": [
+        "Rock",
+        "Water"
+      ],
+      "stats": {
+        "hp": 30,
+        "atk": 80,
+        "def": 90,
+        "spa": 55,
+        "spd": 45,
+        "spe": 55
+      },
+      "abilities": [
+        "Swift Swim",
+        "Battle Armor"
+      ],
+      "weight": 11.5
+    },
+    {
+      "name": "Kabutops",
+      "types": [
+        "Rock",
+        "Water"
+      ],
+      "stats": {
+        "hp": 60,
+        "atk": 115,
+        "def": 105,
+        "spa": 65,
+        "spd": 70,
+        "spe": 80
+      },
+      "abilities": [
+        "Swift Swim",
+        "Battle Armor"
+      ],
+      "weight": 40.5
+    },
+    {
+      "name": "Aerodactyl",
+      "types": [
+        "Rock",
+        "Flying"
+      ],
+      "stats": {
+        "hp": 80,
+        "atk": 105,
+        "def": 65,
+        "spa": 60,
+        "spd": 75,
+        "spe": 130
+      },
+      "abilities": [
+        "Rock Head",
+        "Pressure"
+      ],
+      "weight": 59.0
+    },
+    {
+      "name": "Snorlax",
+      "types": [
+        "Normal"
+      ],
+      "stats": {
+        "hp": 160,
+        "atk": 110,
+        "def": 65,
+        "spa": 65,
+        "spd": 110,
+        "spe": 30
+      },
+      "abilities": [
+        "Immunity",
+        "Thick Fat"
+      ],
+      "weight": 460.0
+    },
+    {
+      "name": "Articuno",
+      "types": [
+        "Ice",
+        "Flying"
+      ],
+      "stats": {
+        "hp": 90,
+        "atk": 85,
+        "def": 100,
+        "spa": 95,
+        "spd": 125,
+        "spe": 85
+      },
+      "abilities": [
+        "Pressure"
+      ],
+      "weight": 55.4
+    },
+    {
+      "name": "Zapdos",
+      "types": [
+        "Electric",
+        "Flying"
+      ],
+      "stats": {
+        "hp": 90,
+        "atk": 90,
+        "def": 85,
+        "spa": 125,
+        "spd": 90,
+        "spe": 100
+      },
+      "abilities": [
+        "Pressure"
+      ],
+      "weight": 52.6
+    },
+    {
+      "name": "Moltres",
+      "types": [
+        "Fire",
+        "Flying"
+      ],
+      "stats": {
+        "hp": 90,
+        "atk": 100,
+        "def": 90,
+        "spa": 125,
+        "spd": 85,
+        "spe": 90
+      },
+      "abilities": [
+        "Pressure"
+      ],
+      "weight": 60.0
+    },
+    {
+      "name": "Dratini",
+      "types": [
+        "Dragon"
+      ],
+      "stats": {
+        "hp": 41,
+        "atk": 64,
+        "def": 45,
+        "spa": 50,
+        "spd": 50,
+        "spe": 50
+      },
+      "abilities": [
+        "Shed Skin"
+      ],
+      "weight": 3.3
+    },
+    {
+      "name": "Dragonair",
+      "types": [
+        "Dragon"
+      ],
+      "stats": {
+        "hp": 61,
+        "atk": 84,
+        "def": 65,
+        "spa": 70,
+        "spd": 70,
+        "spe": 70
+      },
+      "abilities": [
+        "Shed Skin"
+      ],
+      "weight": 16.5
+    },
+    {
+      "name": "Dragonite",
+      "types": [
+        "Dragon",
+        "Flying"
+      ],
+      "stats": {
+        "hp": 91,
+        "atk": 134,
+        "def": 95,
+        "spa": 100,
+        "spd": 100,
+        "spe": 80
+      },
+      "abilities": [
+        "Inner Focus"
+      ],
+      "weight": 210.0
+    },
+    {
+      "name": "Mewtwo",
+      "types": [
+        "Psychic"
+      ],
+      "stats": {
+        "hp": 106,
+        "atk": 110,
+        "def": 90,
+        "spa": 154,
+        "spd": 90,
+        "spe": 130
+      },
+      "abilities": [
+        "Pressure"
+      ],
+      "weight": 122.0
+    },
+    {
+      "name": "Mew",
+      "types": [
+        "Psychic"
+      ],
+      "stats": {
+        "hp": 100,
+        "atk": 100,
+        "def": 100,
+        "spa": 100,
+        "spd": 100,
+        "spe": 100
+      },
+      "abilities": [
+        "Synchronize"
+      ],
+      "weight": 4.0
     }
   ]
-{
-  "name": "Dugtrio",
-  "types": [
-    "Ground"
-  ],
-  "stats": {
-    "hp": 35,
-    "atk": 100,
-    "def": 50,
-    "spa": 50,
-    "spd": 70,
-    "spe": 120
-  },
-  "abilities": [
-    "Sand Veil",
-    "Arena Trap"
-  ],
-  "weight": 33.3
-},
-{
-  "name": "Meowth",
-  "types": [
-    "Normal"
-  ],
-  "stats": {
-    "hp": 40,
-    "atk": 45,
-    "def": 35,
-    "spa": 40,
-    "spd": 40,
-    "spe": 90
-  },
-  "abilities": [
-    "Pickup",
-    "Technician"
-  ],
-  "weight": 4.2
-},
-{
-  "name": "Persian",
-  "types": [
-    "Normal"
-  ],
-  "stats": {
-    "hp": 65,
-    "atk": 70,
-    "def": 60,
-    "spa": 65,
-    "spd": 65,
-    "spe": 115
-  },
-  "abilities": [
-    "Limber",
-    "Technician"
-  ],
-  "weight": 32.0
-},
-{
-  "name": "Psyduck",
-  "types": [
-    "Water"
-  ],
-  "stats": {
-    "hp": 50,
-    "atk": 52,
-    "def": 48,
-    "spa": 65,
-    "spd": 50,
-    "spe": 55
-  },
-  "abilities": [
-    "Damp",
-    "Cloud Nine"
-  ],
-  "weight": 19.6
-},
-{
-  "name": "Golduck",
-  "types": [
-    "Water"
-  ],
-  "stats": {
-    "hp": 80,
-    "atk": 82,
-    "def": 78,
-    "spa": 95,
-    "spd": 80,
-    "spe": 85
-  },
-  "abilities": [
-    "Damp",
-    "Cloud Nine"
-  ],
-  "weight": 76.6
-},
-{
-  "name": "Mankey",
-  "types": [
-    "Fighting"
-  ],
-  "stats": {
-    "hp": 40,
-    "atk": 80,
-    "def": 35,
-    "spa": 35,
-    "spd": 45,
-    "spe": 70
-  },
-  "abilities": [
-    "Vital Spirit",
-    "Anger Point"
-  ],
-  "weight": 28.0
-},
-{
-  "name": "Primeape",
-  "types": [
-    "Fighting"
-  ],
-  "stats": {
-    "hp": 65,
-    "atk": 105,
-    "def": 60,
-    "spa": 60,
-    "spd": 70,
-    "spe": 95
-  },
-  "abilities": [
-    "Vital Spirit",
-    "Anger Point"
-  ],
-  "weight": 32.0
-},
-{
-  "name": "Growlithe",
-  "types": [
-    "Fire"
-  ],
-  "stats": {
-    "hp": 55,
-    "atk": 70,
-    "def": 45,
-    "spa": 70,
-    "spd": 50,
-    "spe": 60
-  },
-  "abilities": [
-    "Intimidate",
-    "Flash Fire"
-  ],
-  "weight": 19.0
-},
-{
-  "name": "Arcanine",
-  "types": [
-    "Fire"
-  ],
-  "stats": {
-    "hp": 90,
-    "atk": 110,
-    "def": 80,
-    "spa": 100,
-    "spd": 80,
-    "spe": 95
-  },
-  "abilities": [
-    "Intimidate",
-    "Flash Fire"
-  ],
-  "weight": 155.0
-},
-{
-  "name": "Poliwag",
-  "types": [
-    "Water"
-  ],
-  "stats": {
-    "hp": 40,
-    "atk": 50,
-    "def": 40,
-    "spa": 40,
-    "spd": 40,
-    "spe": 90
-  },
-  "abilities": [
-    "Water Absorb",
-    "Damp"
-  ],
-  "weight": 12.4
-},
-{
-  "name": "Poliwhirl",
-  "types": [
-    "Water"
-  ],
-  "stats": {
-    "hp": 65,
-    "atk": 65,
-    "def": 65,
-    "spa": 50,
-    "spd": 50,
-    "spe": 90
-  },
-  "abilities": [
-    "Water Absorb",
-    "Damp"
-  ],
-  "weight": 20.0
-},
-{
-  "name": "Poliwrath",
-  "types": [
-    "Water",
-    "Fighting"
-  ],
-  "stats": {
-    "hp": 90,
-    "atk": 95,
-    "def": 95,
-    "spa": 70,
-    "spd": 90,
-    "spe": 70
-  },
-  "abilities": [
-    "Water Absorb",
-    "Damp"
-  ],
-  "weight": 54.0
-},
-{
-  "name": "Abra",
-  "types": [
-    "Psychic"
-  ],
-  "stats": {
-    "hp": 25,
-    "atk": 20,
-    "def": 15,
-    "spa": 105,
-    "spd": 55,
-    "spe": 90
-  },
-  "abilities": [
-    "Synchronize",
-    "Inner Focus"
-  ],
-  "weight": 19.5
-},
-{
-  "name": "Kadabra",
-  "types": [
-    "Psychic"
-  ],
-  "stats": {
-    "hp": 40,
-    "atk": 35,
-    "def": 30,
-    "spa": 120,
-    "spd": 70,
-    "spe": 105
-  },
-  "abilities": [
-    "Synchronize",
-    "Inner Focus"
-  ],
-  "weight": 56.5
-},
-{
-  "name": "Alakazam",
-  "types": [
-    "Psychic"
-  ],
-  "stats": {
-    "hp": 55,
-    "atk": 50,
-    "def": 45,
-    "spa": 135,
-    "spd": 95,
-    "spe": 120
-  },
-  "abilities": [
-    "Synchronize",
-    "Inner Focus"
-  ],
-  "weight": 48.0
-},
-{
-  "name": "Machop",
-  "types": [
-    "Fighting"
-  ],
-  "stats": {
-    "hp": 70,
-    "atk": 80,
-    "def": 50,
-    "spa": 35,
-    "spd": 35,
-    "spe": 35
-  },
-  "abilities": [
-    "Guts",
-    "No Guard"
-  ],
-  "weight": 19.5
-},
-{
-  "name": "Machoke",
-  "types": [
-    "Fighting"
-  ],
-  "stats": {
-    "hp": 80,
-    "atk": 100,
-    "def": 70,
-    "spa": 50,
-    "spd": 60,
-    "spe": 45
-  },
-  "abilities": [
-    "Guts",
-    "No Guard"
-  ],
-  "weight": 70.5
-},
-{
-  "name": "Machamp",
-  "types": [
-    "Fighting"
-  ],
-  "stats": {
-    "hp": 90,
-    "atk": 130,
-    "def": 80,
-    "spa": 65,
-    "spd": 85,
-    "spe": 55
-  },
-  "abilities": [
-    "Guts",
-    "No Guard"
-  ],
-  "weight": 130.0
-},
-{
-  "name": "Bellsprout",
-  "types": [
-    "Grass",
-    "Poison"
-  ],
-  "stats": {
-    "hp": 50,
-    "atk": 75,
-    "def": 35,
-    "spa": 70,
-    "spd": 30,
-    "spe": 40
-  },
-  "abilities": [
-    "Chlorophyll"
-  ],
-  "weight": 4.0
-},
-{
-  "name": "Weepinbell",
-  "types": [
-    "Grass",
-    "Poison"
-  ],
-  "stats": {
-    "hp": 65,
-    "atk": 90,
-    "def": 50,
-    "spa": 85,
-    "spd": 45,
-    "spe": 55
-  },
-  "abilities": [
-    "Chlorophyll"
-  ],
-  "weight": 6.4
-},
-{
-  "name": "Victreebel",
-  "types": [
-    "Grass",
-    "Poison"
-  ],
-  "stats": {
-    "hp": 80,
-    "atk": 105,
-    "def": 65,
-    "spa": 100,
-    "spd": 70,
-    "spe": 70
-  },
-  "abilities": [
-    "Chlorophyll"
-  ],
-  "weight": 15.5
-},
-{
-  "name": "Tentacool",
-  "types": [
-    "Water",
-    "Poison"
-  ],
-  "stats": {
-    "hp": 40,
-    "atk": 40,
-    "def": 35,
-    "spa": 50,
-    "spd": 100,
-    "spe": 70
-  },
-  "abilities": [
-    "Clear Body",
-    "Liquid Ooze"
-  ],
-  "weight": 45.5
-},
-{
-  "name": "Tentacruel",
-  "types": [
-    "Water",
-    "Poison"
-  ],
-  "stats": {
-    "hp": 80,
-    "atk": 70,
-    "def": 65,
-    "spa": 80,
-    "spd": 120,
-    "spe": 100
-  },
-  "abilities": [
-    "Clear Body",
-    "Liquid Ooze"
-  ],
-  "weight": 55.0
-},
-{
-  "name": "Geodude",
-  "types": [
-    "Rock",
-    "Ground"
-  ],
-  "stats": {
-    "hp": 40,
-    "atk": 80,
-    "def": 100,
-    "spa": 30,
-    "spd": 30,
-    "spe": 20
-  },
-  "abilities": [
-    "Rock Head",
-    "Sturdy"
-  ],
-  "weight": 20.0
-},
-{
-  "name": "Graveler",
-  "types": [
-    "Rock",
-    "Ground"
-  ],
-  "stats": {
-    "hp": 55,
-    "atk": 95,
-    "def": 115,
-    "spa": 45,
-    "spd": 45,
-    "spe": 35
-  },
-  "abilities": [
-    "Rock Head",
-    "Sturdy"
-  ],
-  "weight": 105.0
-},
-{
-  "name": "Golem",
-  "types": [
-    "Rock",
-    "Ground"
-  ],
-  "stats": {
-    "hp": 80,
-    "atk": 120,
-    "def": 130,
-    "spa": 55,
-    "spd": 65,
-    "spe": 45
-  },
-  "abilities": [
-    "Rock Head",
-    "Sturdy"
-  ],
-  "weight": 300.0
-},
-{
-  "name": "Ponyta",
-  "types": [
-    "Fire"
-  ],
-  "stats": {
-    "hp": 50,
-    "atk": 85,
-    "def": 55,
-    "spa": 65,
-    "spd": 65,
-    "spe": 90
-  },
-  "abilities": [
-    "Run Away",
-    "Flash Fire"
-  ],
-  "weight": 30.0
-},
-{
-  "name": "Rapidash",
-  "types": [
-    "Fire"
-  ],
-  "stats": {
-    "hp": 65,
-    "atk": 100,
-    "def": 70,
-    "spa": 80,
-    "spd": 80,
-    "spe": 105
-  },
-  "abilities": [
-    "Run Away",
-    "Flash Fire"
-  ],
-  "weight": 95.0
-},
-{
-  "name": "Slowpoke",
-  "types": [
-    "Water",
-    "Psychic"
-  ],
-  "stats": {
-    "hp": 90,
-    "atk": 65,
-    "def": 65,
-    "spa": 40,
-    "spd": 40,
-    "spe": 15
-  },
-  "abilities": [
-    "Oblivious",
-    "Own Tempo"
-  ],
-  "weight": 36.0
-},
-{
-  "name": "Slowbro",
-  "types": [
-    "Water",
-    "Psychic"
-  ],
-  "stats": {
-    "hp": 95,
-    "atk": 75,
-    "def": 110,
-    "spa": 100,
-    "spd": 80,
-    "spe": 30
-  },
-  "abilities": [
-    "Oblivious",
-    "Own Tempo"
-  ],
-  "weight": 78.5
-},
-{
-  "name": "Magnemite",
-  "types": [
-    "Electric",
-    "Steel"
-  ],
-  "stats": {
-    "hp": 25,
-    "atk": 35,
-    "def": 70,
-    "spa": 95,
-    "spd": 55,
-    "spe": 45
-  },
-  "abilities": [
-    "Magnet Pull",
-    "Sturdy"
-  ],
-  "weight": 6.0
-},
-{
-  "name": "Magneton",
-  "types": [
-    "Electric",
-    "Steel"
-  ],
-  "stats": {
-    "hp": 50,
-    "atk": 60,
-    "def": 95,
-    "spa": 120,
-    "spd": 70,
-    "spe": 70
-  },
-  "abilities": [
-    "Magnet Pull",
-    "Sturdy"
-  ],
-  "weight": 60.0
-},
-{
-  "name": "Farfetch'd",
-  "types": [
-    "Normal",
-    "Flying"
-  ],
-  "stats": {
-    "hp": 52,
-    "atk": 90,
-    "def": 55,
-    "spa": 58,
-    "spd": 62,
-    "spe": 60
-  },
-  "abilities": [
-    "Keen Eye",
-    "Inner Focus"
-  ],
-  "weight": 15.0
-},
-{
-  "name": "Doduo",
-  "types": [
-    "Normal",
-    "Flying"
-  ],
-  "stats": {
-    "hp": 35,
-    "atk": 85,
-    "def": 45,
-    "spa": 35,
-    "spd": 35,
-    "spe": 75
-  },
-  "abilities": [
-    "Run Away",
-    "Early Bird"
-  ],
-  "weight": 39.2
-},
-{
-  "name": "Dodrio",
-  "types": [
-    "Normal",
-    "Flying"
-  ],
-  "stats": {
-    "hp": 60,
-    "atk": 110,
-    "def": 70,
-    "spa": 60,
-    "spd": 60,
-    "spe": 110
-  },
-  "abilities": [
-    "Run Away",
-    "Early Bird"
-  ],
-  "weight": 85.2
-},
-{
-  "name": "Seel",
-  "types": [
-    "Water"
-  ],
-  "stats": {
-    "hp": 65,
-    "atk": 45,
-    "def": 55,
-    "spa": 45,
-    "spd": 70,
-    "spe": 45
-  },
-  "abilities": [
-    "Thick Fat",
-    "Hydration"
-  ],
-  "weight": 90.0
-},
-{
-  "name": "Dewgong",
-  "types": [
-    "Water",
-    "Ice"
-  ],
-  "stats": {
-    "hp": 90,
-    "atk": 70,
-    "def": 80,
-    "spa": 70,
-    "spd": 95,
-    "spe": 70
-  },
-  "abilities": [
-    "Thick Fat",
-    "Hydration"
-  ],
-  "weight": 120.0
-},
-{
-  "name": "Grimer",
-  "types": [
-    "Poison"
-  ],
-  "stats": {
-    "hp": 80,
-    "atk": 80,
-    "def": 50,
-    "spa": 40,
-    "spd": 50,
-    "spe": 25
-  },
-  "abilities": [
-    "Stench",
-    "Sticky Hold"
-  ],
-  "weight": 30.0
-},
-{
-  "name": "Muk",
-  "types": [
-    "Poison"
-  ],
-  "stats": {
-    "hp": 105,
-    "atk": 105,
-    "def": 75,
-    "spa": 65,
-    "spd": 100,
-    "spe": 50
-  },
-  "abilities": [
-    "Stench",
-    "Sticky Hold"
-  ],
-  "weight": 30.0
-},
-{
-  "name": "Shellder",
-  "types": [
-    "Water"
-  ],
-  "stats": {
-    "hp": 30,
-    "atk": 65,
-    "def": 100,
-    "spa": 45,
-    "spd": 25,
-    "spe": 40
-  },
-  "abilities": [
-    "Shell Armor",
-    "Skill Link"
-  ],
-  "weight": 4.0
-},
-{
-  "name": "Cloyster",
-  "types": [
-    "Water",
-    "Ice"
-  ],
-  "stats": {
-    "hp": 50,
-    "atk": 95,
-    "def": 180,
-    "spa": 85,
-    "spd": 45,
-    "spe": 70
-  },
-  "abilities": [
-    "Shell Armor",
-    "Skill Link"
-  ],
-  "weight": 132.5
-},
-{
-  "name": "Gastly",
-  "types": [
-    "Ghost",
-    "Poison"
-  ],
-  "stats": {
-    "hp": 30,
-    "atk": 35,
-    "def": 30,
-    "spa": 100,
-    "spd": 35,
-    "spe": 80
-  },
-  "abilities": [
-    "Levitate"
-  ],
-  "weight": 0.1
-},
-{
-  "name": "Haunter",
-  "types": [
-    "Ghost",
-    "Poison"
-  ],
-  "stats": {
-    "hp": 45,
-    "atk": 50,
-    "def": 45,
-    "spa": 115,
-    "spd": 55,
-    "spe": 95
-  },
-  "abilities": [
-    "Levitate"
-  ],
-  "weight": 0.1
-},
-{
-  "name": "Gengar",
-  "types": [
-    "Ghost",
-    "Poison"
-  ],
-  "stats": {
-    "hp": 60,
-    "atk": 65,
-    "def": 60,
-    "spa": 130,
-    "spd": 75,
-    "spe": 110
-  },
-  "abilities": [
-    "Cursed Body"
-  ],
-  "weight": 40.5
-},
-{
-  "name": "Onix",
-  "types": [
-    "Rock",
-    "Ground"
-  ],
-  "stats": {
-    "hp": 35,
-    "atk": 45,
-    "def": 160,
-    "spa": 30,
-    "spd": 45,
-    "spe": 70
-  },
-  "abilities": [
-    "Rock Head",
-    "Sturdy"
-  ],
-  "weight": 210.0
-},
-{
-  "name": "Drowzee",
-  "types": [
-    "Psychic"
-  ],
-  "stats": {
-    "hp": 60,
-    "atk": 48,
-    "def": 45,
-    "spa": 43,
-    "spd": 90,
-    "spe": 42
-  },
-  "abilities": [
-    "Insomnia",
-    "Forewarn"
-  ],
-  "weight": 32.4
-},
-{
-  "name": "Hypno",
-  "types": [
-    "Psychic"
-  ],
-  "stats": {
-    "hp": 85,
-    "atk": 73,
-    "def": 70,
-    "spa": 73,
-    "spd": 115,
-    "spe": 67
-  },
-  "abilities": [
-    "Insomnia",
-    "Forewarn"
-  ],
-  "weight": 75.6
-},
-{
-  "name": "Krabby",
-  "types": [
-    "Water"
-  ],
-  "stats": {
-    "hp": 30,
-    "atk": 105,
-    "def": 90,
-    "spa": 25,
-    "spd": 25,
-    "spe": 50
-  },
-  "abilities": [
-    "Hyper Cutter",
-    "Shell Armor"
-  ],
-  "weight": 6.5
-},
-{
-  "name": "Kingler",
-  "types": [
-    "Water"
-  ],
-  "stats": {
-    "hp": 55,
-    "atk": 130,
-    "def": 115,
-    "spa": 50,
-    "spd": 50,
-    "spe": 75
-  },
-  "abilities": [
-    "Hyper Cutter",
-    "Shell Armor"
-  ],
-  "weight": 60.0
-},
-{
-  "name": "Voltorb",
-  "types": [
-    "Electric"
-  ],
-  "stats": {
-    "hp": 40,
-    "atk": 30,
-    "def": 50,
-    "spa": 55,
-    "spd": 55,
-    "spe": 100
-  },
-  "abilities": [
-    "Soundproof",
-    "Static"
-  ],
-  "weight": 10.4
-},
-  ]
 }
-


### PR DESCRIPTION
## Summary
- expanded `PokemonGen1.json` with entries for all 151 Pokémon

## Testing
- `npm test` *(fails: vitest not found)*