### PR TITLE
Enable vitest and add utils tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "preview": "vite preview",
     "dev:ui": "vite --root src/battle-ui",
     "dev:analytics": "vite --root src/analytics/reporting",
-    "test": "vitest"
+    "test": "vitest run"
   },
   "keywords": [],
   "author": "",

--- a/src/engine/__tests__/Utils.test.ts
+++ b/src/engine/__tests__/Utils.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from 'vitest'
+import { LCG, randInt, shuffle } from '../Utils'
+
+describe('LCG', () => {
+  it('generates deterministic sequence with same seed', () => {
+    const lcg1 = new LCG(1)
+    const lcg2 = new LCG(1)
+    const values1 = [lcg1.next(), lcg1.next(), lcg1.next()]
+    const values2 = [lcg2.next(), lcg2.next(), lcg2.next()]
+    expect(values1).toEqual(values2)
+  })
+})
+
+describe('randInt', () => {
+  it('generates numbers in inclusive range', () => {
+    const rng = () => 0.5
+    const num = randInt(1, 3, rng)
+    expect(num).toBe(2)
+  })
+})
+
+describe('shuffle', () => {
+  it('shuffles array elements', () => {
+    const arr = [1, 2, 3]
+    const shuffled = shuffle([...arr])
+    expect(shuffled.sort()).toEqual(arr)
+  })
+})


### PR DESCRIPTION
## Summary
- configure `npm test` to run vitest without watch mode
- add initial unit tests for engine utils

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_683f6d1c8ab8832e9b25a87737c6c587